### PR TITLE
Update comedy_errors.4.3.html

### DIFF
--- a/comedy_errors/comedy_errors.4.3.html
+++ b/comedy_errors/comedy_errors.4.3.html
@@ -24,13 +24,10 @@
 <H3>SCENE III. A public place.</h3>
 
 <p><blockquote>
-<i>Enter ANTIPHOLUS of Syracuse</i>
-</blockquote>
-<blockquote>
-<A NAME=1>ANTIPHOLUS</A><br>
+<i>Enter ANTIPHOLUS OF SYRACUSE</i>
 </blockquote>
 
-<A NAME=speech1><b>OF SYRACUSE</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2>There's not a man I meet but doth salute me</A><br>
 <A NAME=3>As if I were their well-acquainted friend;</A><br>
@@ -50,10 +47,9 @@
 <blockquote>
 <A NAME=13>Master, here's the gold you sent me for. What, have</A><br>
 <A NAME=14>you got the picture of old Adam new-apparelled?</A><br>
-<A NAME=15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF SYRACUSE</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=16>What gold is this? what Adam dost thou mean?</A><br>
 </blockquote>
@@ -65,10 +61,9 @@
 <A NAME=19>skin that was killed for the Prodigal; he that came</A><br>
 <A NAME=20>behind you, sir, like an evil angel, and bid you</A><br>
 <A NAME=21>forsake your liberty.</A><br>
-<A NAME=22>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF SYRACUSE</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=23>I understand thee not.</A><br>
 </blockquote>
@@ -82,10 +77,9 @@
 <A NAME=28>men and gives them suits of durance; he that sets up</A><br>
 <A NAME=29>his rest to do more exploits with his mace than a</A><br>
 <A NAME=30>morris-pike.</A><br>
-<A NAME=31>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF SYRACUSE</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=32>What, thou meanest an officer?</A><br>
 </blockquote>
@@ -96,10 +90,9 @@
 <A NAME=34>any man to answer it that breaks his band; one that</A><br>
 <A NAME=35>thinks a man always going to bed, and says, 'God</A><br>
 <A NAME=36>give you good rest!'</A><br>
-<A NAME=37>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF SYRACUSE</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=38>Well, sir, there rest in your foolery. Is there any</A><br>
 </blockquote>
@@ -111,10 +104,9 @@
 <A NAME=41>you hindered by the sergeant, to tarry for the hoy</A><br>
 <A NAME=42>Delay. Here are the angels that you sent for to</A><br>
 <A NAME=43>deliver you.</A><br>
-<A NAME=44>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech11><b>OF SYRACUSE</b></a>
+<A NAME=speech11><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=45>The fellow is distract, and so am I;</A><br>
 <A NAME=46>And here we wander in illusions:</A><br>
@@ -122,15 +114,14 @@
 <p><i>Enter a Courtezan</i></p>
 </blockquote>
 
-<A NAME=speech12><b>Courtezan</b></a>
+<A NAME=speech12><b>COURTEZAN</b></a>
 <blockquote>
 <A NAME=48>Well met, well met, Master Antipholus.</A><br>
 <A NAME=49>I see, sir, you have found the goldsmith now:</A><br>
 <A NAME=50>Is that the chain you promised me to-day?</A><br>
-<A NAME=51>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech13><b>OF SYRACUSE</b></a>
+<A NAME=speech13><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=52>Satan, avoid! I charge thee, tempt me not.</A><br>
 </blockquote>
@@ -138,10 +129,9 @@
 <A NAME=speech14><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=53>Master, is this Mistress Satan?</A><br>
-<A NAME=54>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech15><b>OF SYRACUSE</b></a>
+<A NAME=speech15><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=55>It is the devil.</A><br>
 </blockquote>
@@ -157,7 +147,7 @@
 <A NAME=62>ergo, light wenches will burn. Come not near her.</A><br>
 </blockquote>
 
-<A NAME=speech17><b>Courtezan</b></a>
+<A NAME=speech17><b>COURTEZAN</b></a>
 <blockquote>
 <A NAME=63>Your man and you are marvellous merry, sir.</A><br>
 <A NAME=64>Will you go with me? We'll mend our dinner here?</A><br>
@@ -167,10 +157,9 @@
 <blockquote>
 <A NAME=65>Master, if you do, expect spoon-meat; or bespeak a</A><br>
 <A NAME=66>long spoon.</A><br>
-<A NAME=67>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech19><b>OF SYRACUSE</b></a>
+<A NAME=speech19><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=68>Why, Dromio?</A><br>
 </blockquote>
@@ -179,17 +168,16 @@
 <blockquote>
 <A NAME=69>Marry, he must have a long spoon that must eat with</A><br>
 <A NAME=70>the devil.</A><br>
-<A NAME=71>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech21><b>OF SYRACUSE</b></a>
+<A NAME=speech21><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=72>Avoid then, fiend! what tell'st thou me of supping?</A><br>
 <A NAME=73>Thou art, as you are all, a sorceress:</A><br>
 <A NAME=74>I conjure thee to leave me and be gone.</A><br>
 </blockquote>
 
-<A NAME=speech22><b>Courtezan</b></a>
+<A NAME=speech22><b>COURTEZAN</b></a>
 <blockquote>
 <A NAME=75>Give me the ring of mine you had at dinner,</A><br>
 <A NAME=76>Or, for my diamond, the chain you promised,</A><br>
@@ -206,14 +194,13 @@
 <A NAME=83>The devil will shake her chain and fright us with it.</A><br>
 </blockquote>
 
-<A NAME=speech24><b>Courtezan</b></a>
+<A NAME=speech24><b>COURTEZAN</b></a>
 <blockquote>
 <A NAME=84>I pray you, sir, my ring, or else the chain:</A><br>
 <A NAME=85>I hope you do not mean to cheat me so.</A><br>
-<A NAME=86>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech25><b>OF SYRACUSE</b></a>
+<A NAME=speech25><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=87>Avaunt, thou witch! Come, Dromio, let us go.</A><br>
 </blockquote>
@@ -224,7 +211,7 @@
 <p><i>Exeunt Antipholus of Syracuse and Dromio of Syracuse</i></p>
 </blockquote>
 
-<A NAME=speech27><b>Courtezan</b></a>
+<A NAME=speech27><b>COURTEZAN</b></a>
 <blockquote>
 <A NAME=89>Now, out of doubt Antipholus is mad,</A><br>
 <A NAME=90>Else would he never so demean himself.</A><br>


### PR DESCRIPTION
Fix speech headings to display on a single line; standardize capitalization for speech headings and stage directions.