### PR TITLE
fixed typo: barded -> barbed

### DIFF
--- a/richardiii/full.html
+++ b/richardiii/full.html
@@ -35,7 +35,7 @@
 <A NAME=1.1.7>Our stern alarums changed to merry meetings,</A><br>
 <A NAME=1.1.8>Our dreadful marches to delightful measures.</A><br>
 <A NAME=1.1.9>Grim-visaged war hath smooth'd his wrinkled front;</A><br>
-<A NAME=1.1.10>And now, instead of mounting barded steeds</A><br>
+<A NAME=1.1.10>And now, instead of mounting barbed steeds</A><br>
 <A NAME=1.1.11>To fright the souls of fearful adversaries,</A><br>
 <A NAME=1.1.12>He capers nimbly in a lady's chamber</A><br>
 <A NAME=1.1.13>To the lascivious pleasing of a lute.</A><br>

--- a/richardiii/richardiii.1.1.html
+++ b/richardiii/richardiii.1.1.html
@@ -37,7 +37,7 @@
 <A NAME=7>Our stern alarums changed to merry meetings,</A><br>
 <A NAME=8>Our dreadful marches to delightful measures.</A><br>
 <A NAME=9>Grim-visaged war hath smooth'd his wrinkled front;</A><br>
-<A NAME=10>And now, instead of mounting barded steeds</A><br>
+<A NAME=10>And now, instead of mounting barbed steeds</A><br>
 <A NAME=11>To fright the souls of fearful adversaries,</A><br>
 <A NAME=12>He capers nimbly in a lady's chamber</A><br>
 <A NAME=13>To the lascivious pleasing of a lute.</A><br>


### PR DESCRIPTION
The tenth line of Act 1 Scene 1 of Richard III reads "And now, instead of mounting barded steeds". The original text, according to the Folger Shakespeare Library, is "And now, instead of mounting barbèd steeds."

@moderators, would you like me to put an accented e (`&#232;`) in "barbèd"? Or is that inconsistent with the rest of the repository?