### PR TITLE
Remove broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,6 @@ of William Shakespeare.  This site has offered Shakespeare's plays and
 poetry to the Internet community since 1993.
 </blockquote>
 
-<P>For other Shakespeare resources, visit the <A
-href="http://shakespeare.palomar.edu/">Mr. William Shakespeare
-and the Internet</A> Web site.
-
 <P>The original electronic source for this server was the Complete
 Moby(tm) Shakespeare. The HTML versions of the plays provided here are placed in the public domain.
 


### PR DESCRIPTION
http://shakespeare.palomar.edu/ link is broken. The current version of the PR removes it, however it could be updated to link to https://www.folger.edu or https://www.shakespearesglobe.com