### PR TITLE
Fix many typos with character names and scene names

### DIFF
--- a/1henryiv/1henryiv.3.2.html
+++ b/1henryiv/1henryiv.3.2.html
@@ -247,7 +247,7 @@
 <p><i>Exeunt</i></p>
 </blockquote>
 
-<A NAME=speech10><b>Scene III</b></a>
+<A NAME=speech10><b>SCENE III</b></a>
 <blockquote>
 <A NAME=182>Eastcheap. The Boar's-Head Tavern.</A><br>
 <p><i>Enter FALSTAFF and BARDOLPH</i></p>

--- a/1henryiv/full.html
+++ b/1henryiv/full.html
@@ -4076,7 +4076,7 @@
 <p><i>Exeunt</i></p>
 </blockquote>
 
-<A NAME=speech10><b>Scene III</b></a>
+<A NAME=speech10><b>SCENE III</b></a>
 <blockquote>
 <A NAME=3.2.182>Eastcheap. The Boar's-Head Tavern.</A><br>
 <p><i>Enter FALSTAFF and BARDOLPH</i></p>

--- a/2henryiv/2henryiv.0.0.html
+++ b/2henryiv/2henryiv.0.0.html
@@ -20,8 +20,8 @@
       <a href="2henryiv.1.1.html">Next scene</A>
 </table>
 
-<h3>Induction</H3>
-
+<H3>ACT Induction</H3>
+<h3>SCENE I.</h3>
 <p><blockquote>
 <i>Warkworth. Before the castle</i>
 </blockquote>

--- a/2henryiv/2henryiv.0.0.html
+++ b/2henryiv/2henryiv.0.0.html
@@ -20,6 +20,8 @@
       <a href="2henryiv.1.1.html">Next scene</A>
 </table>
 
+<h3>Induction</H3>
+
 <p><blockquote>
 <i>Warkworth. Before the castle</i>
 </blockquote>

--- a/2henryiv/2henryiv.0.0.html
+++ b/2henryiv/2henryiv.0.0.html
@@ -20,8 +20,6 @@
       <a href="2henryiv.1.1.html">Next scene</A>
 </table>
 
-<H3>ACT Induction</H3>
-<h3>SCENE I.</h3>
 <p><blockquote>
 <i>Warkworth. Before the castle</i>
 </blockquote>

--- a/2henryiv/full.html
+++ b/2henryiv/full.html
@@ -18,8 +18,6 @@
     | Entire play
 </table>
 
-<H3>ACT Induction</h3>
-<h3>SCENE I.</h3>
 <p><blockquote>
 <i>Warkworth. Before the castle</i>
 </blockquote>

--- a/2henryiv/full.html
+++ b/2henryiv/full.html
@@ -18,7 +18,8 @@
     | Entire play
 </table>
 
-<h3>None</h3>
+<H3>ACT Induction</h3>
+<h3>SCENE I.</h3>
 <p><blockquote>
 <i>Warkworth. Before the castle</i>
 </blockquote>

--- a/2henryiv/full.html
+++ b/2henryiv/full.html
@@ -18,6 +18,8 @@
     | Entire play
 </table>
 
+<h3>Induction</H3>
+
 <p><blockquote>
 <i>Warkworth. Before the castle</i>
 </blockquote>

--- a/2henryvi/2henryvi.3.2.html
+++ b/2henryvi/2henryvi.3.2.html
@@ -40,7 +40,7 @@
 <p><i>Enter SUFFOLK</i></p>
 </blockquote>
 
-<A NAME=speech3><b>First Murder</b></a>
+<A NAME=speech3><b>First Murderer</b></a>
 <blockquote>
 <A NAME=5>Here comes my lord.</A><br>
 </blockquote>

--- a/2henryvi/full.html
+++ b/2henryvi/full.html
@@ -3233,7 +3233,7 @@
 <p><i>Enter SUFFOLK</i></p>
 </blockquote>
 
-<A NAME=speech3><b>First Murder</b></a>
+<A NAME=speech3><b>First Murderer</b></a>
 <blockquote>
 <A NAME=3.2.5>Here comes my lord.</A><br>
 </blockquote>

--- a/History/1kinghenryiv/1henryiv.3.2.html
+++ b/History/1kinghenryiv/1henryiv.3.2.html
@@ -247,7 +247,7 @@
 <p><i>Exeunt</i></p>
 </blockquote>
 
-<A NAME=speech10><b>Scene III</b></a>
+<A NAME=speech10><b>SCENE III</b></a>
 <blockquote>
 <A NAME=182>Eastcheap. The Boar's-Head Tavern.</A><br>
 <p><i>Enter FALSTAFF and BARDOLPH</i></p>

--- a/History/1kinghenryiv/full.html
+++ b/History/1kinghenryiv/full.html
@@ -4076,7 +4076,7 @@
 <p><i>Exeunt</i></p>
 </blockquote>
 
-<A NAME=speech10><b>Scene III</b></a>
+<A NAME=speech10><b>SCENE III</b></a>
 <blockquote>
 <A NAME=3.2.182>Eastcheap. The Boar's-Head Tavern.</A><br>
 <p><i>Enter FALSTAFF and BARDOLPH</i></p>

--- a/History/2kinghenryvi/2henryvi.3.2.html
+++ b/History/2kinghenryvi/2henryvi.3.2.html
@@ -40,7 +40,7 @@
 <p><i>Enter SUFFOLK</i></p>
 </blockquote>
 
-<A NAME=speech3><b>First Murder</b></a>
+<A NAME=speech3><b>First Murderer</b></a>
 <blockquote>
 <A NAME=5>Here comes my lord.</A><br>
 </blockquote>

--- a/History/2kinghenryvi/full.html
+++ b/History/2kinghenryvi/full.html
@@ -3233,7 +3233,7 @@
 <p><i>Enter SUFFOLK</i></p>
 </blockquote>
 
-<A NAME=speech3><b>First Murder</b></a>
+<A NAME=speech3><b>First Murderer</b></a>
 <blockquote>
 <A NAME=3.2.5>Here comes my lord.</A><br>
 </blockquote>

--- a/allswell/allswell.3.5.html
+++ b/allswell/allswell.3.5.html
@@ -330,7 +330,7 @@
 <A NAME=113>Worthy the note.</A><br>
 </blockquote>
 
-<A NAME=speech47><b>BOTH</b></a>
+<A NAME=speech47><b>Both</b></a>
 <blockquote>
 <A NAME=114>                  We'll take your offer kindly.</A><br>
 <p><i>Exeunt</i></p>

--- a/allswell/full.html
+++ b/allswell/full.html
@@ -3830,7 +3830,7 @@
 <A NAME=3.5.113>Worthy the note.</A><br>
 </blockquote>
 
-<A NAME=speech47><b>BOTH</b></a>
+<A NAME=speech47><b>Both</b></a>
 <blockquote>
 <A NAME=3.5.114>                  We'll take your offer kindly.</A><br>
 <p><i>Exeunt</i></p>

--- a/asyoulikeit/asyoulikeit.4.2.html
+++ b/asyoulikeit/asyoulikeit.4.2.html
@@ -32,7 +32,7 @@
 <A NAME=1>Which is he that killed the deer?</A><br>
 </blockquote>
 
-<A NAME=speech2><b>A Lord</b></a>
+<A NAME=speech2><b>Lord</b></a>
 <blockquote>
 <A NAME=2>Sir, it was I.</A><br>
 </blockquote>

--- a/asyoulikeit/full.html
+++ b/asyoulikeit/full.html
@@ -4684,7 +4684,7 @@
 <A NAME=4.2.1>Which is he that killed the deer?</A><br>
 </blockquote>
 
-<A NAME=speech2><b>A Lord</b></a>
+<A NAME=speech2><b>Lord</b></a>
 <blockquote>
 <A NAME=4.2.2>Sir, it was I.</A><br>
 </blockquote>

--- a/comedy_errors/comedy_errors.1.2.html
+++ b/comedy_errors/comedy_errors.1.2.html
@@ -37,10 +37,9 @@
 <A NAME=6>According to the statute of the town,</A><br>
 <A NAME=7>Dies ere the weary sun set in the west.</A><br>
 <A NAME=8>There is your money that I had to keep.</A><br>
-<A NAME=9>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech2><b>OF SYRACUSE</b></a>
+<A NAME=speech2><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=10>Go bear it to the Centaur, where we host,</A><br>
 <A NAME=11>And stay there, Dromio, till I come to thee.</A><br>
@@ -57,10 +56,9 @@
 <A NAME=18>Many a man would take you at your word,</A><br>
 <A NAME=19>And go indeed, having so good a mean.</A><br>
 <p><i>Exit</i></p>
-<A NAME=20>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech4><b>OF SYRACUSE</b></a>
+<A NAME=speech4><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=21>A trusty villain, sir, that very oft,</A><br>
 <A NAME=22>When I am dull with care and melancholy,</A><br>
@@ -77,10 +75,9 @@
 <A NAME=29>Please you, I'll meet with you upon the mart</A><br>
 <A NAME=30>And afterward consort you till bed-time:</A><br>
 <A NAME=31>My present business calls me from you now.</A><br>
-<A NAME=32>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF SYRACUSE</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=33>Farewell till then: I will go lose myself</A><br>
 <A NAME=34>And wander up and down to view the city.</A><br>
@@ -90,10 +87,9 @@
 <blockquote>
 <A NAME=35>Sir, I commend you to your own content.</A><br>
 <p><i>Exit</i></p>
-<A NAME=36>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF SYRACUSE</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=37>He that commends me to mine own content</A><br>
 <A NAME=38>Commends me to the thing I cannot get.</A><br>
@@ -120,10 +116,9 @@
 <A NAME=54>You have no stomach having broke your fast;</A><br>
 <A NAME=55>But we that know what 'tis to fast and pray</A><br>
 <A NAME=56>Are penitent for your default to-day.</A><br>
-<A NAME=57>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF SYRACUSE</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=58>Stop in your wind, sir: tell me this, I pray:</A><br>
 <A NAME=59>Where have you left the money that I gave you?</A><br>
@@ -134,10 +129,9 @@
 <A NAME=60>O,--sixpence, that I had o' Wednesday last</A><br>
 <A NAME=61>To pay the saddler for my mistress' crupper?</A><br>
 <A NAME=62>The saddler had it, sir; I kept it not.</A><br>
-<A NAME=63>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech12><b>OF SYRACUSE</b></a>
+<A NAME=speech12><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=64>I am not in a sportive humour now:</A><br>
 <A NAME=65>Tell me, and dally not, where is the money?</A><br>
@@ -153,10 +147,9 @@
 <A NAME=71>For she will score your fault upon my pate.</A><br>
 <A NAME=72>Methinks your maw, like mine, should be your clock,</A><br>
 <A NAME=73>And strike you home without a messenger.</A><br>
-<A NAME=74>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF SYRACUSE</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=75>Come, Dromio, come, these jests are out of season;</A><br>
 <A NAME=76>Reserve them till a merrier hour than this.</A><br>
@@ -166,10 +159,9 @@
 <A NAME=speech15><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=78>To me, sir? why, you gave no gold to me.</A><br>
-<A NAME=79>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech16><b>OF SYRACUSE</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=80>Come on, sir knave, have done your foolishness,</A><br>
 <A NAME=81>And tell me how thou hast disposed thy charge.</A><br>
@@ -180,10 +172,9 @@
 <A NAME=82>My charge was but to fetch you from the mart</A><br>
 <A NAME=83>Home to your house, the Phoenix, sir, to dinner:</A><br>
 <A NAME=84>My mistress and her sister stays for you.</A><br>
-<A NAME=85>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF SYRACUSE</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=86>In what safe place you have bestow'd my money,</A><br>
 <A NAME=87>Or I shall break that merry sconce of yours</A><br>
@@ -198,10 +189,9 @@
 <A NAME=92>But not a thousand marks between you both.</A><br>
 <A NAME=93>If I should pay your worship those again,</A><br>
 <A NAME=94>Perchance you will not bear them patiently.</A><br>
-<A NAME=95>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech20><b>OF SYRACUSE</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=96>Thy mistress' marks? what mistress, slave, hast thou?</A><br>
 </blockquote>
@@ -211,10 +201,9 @@
 <A NAME=97>Your worship's wife, my mistress at the Phoenix;</A><br>
 <A NAME=98>She that doth fast till you come home to dinner,</A><br>
 <A NAME=99>And prays that you will hie you home to dinner.</A><br>
-<A NAME=100>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech22><b>OF SYRACUSE</b></a>
+<A NAME=speech22><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=101>What, wilt thou flout me thus unto my face,</A><br>
 <A NAME=102>Being forbid? There, take you that, sir knave.</A><br>
@@ -225,10 +214,9 @@
 <A NAME=103>What mean you, sir? for God's sake, hold your hands!</A><br>
 <A NAME=104>Nay, and you will not, sir, I'll take my heels.</A><br>
 <p><i>Exit</i></p>
-<A NAME=105>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech24><b>OF SYRACUSE</b></a>
+<A NAME=speech24><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=106>Upon my life, by some device or other</A><br>
 <A NAME=107>The villain is o'er-raught of all my money.</A><br>

--- a/comedy_errors/comedy_errors.2.2.html
+++ b/comedy_errors/comedy_errors.2.2.html
@@ -26,11 +26,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Syracuse</i>
 </blockquote>
-<blockquote>
-<A NAME=1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF SYRACUSE</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2>The gold I gave to Dromio is laid up</A><br>
 <A NAME=3>Safe at the Centaur; and the heedful slave</A><br>
@@ -50,10 +47,9 @@
 <A NAME=speech2><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=14>What answer, sir? when spake I such a word?</A><br>
-<A NAME=15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF SYRACUSE</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=16>Even now, even here, not half an hour since.</A><br>
 </blockquote>
@@ -62,10 +58,9 @@
 <blockquote>
 <A NAME=17>I did not see you since you sent me hence,</A><br>
 <A NAME=18>Home to the Centaur, with the gold you gave me.</A><br>
-<A NAME=19>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF SYRACUSE</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=20>Villain, thou didst deny the gold's receipt,</A><br>
 <A NAME=21>And told'st me of a mistress and a dinner;</A><br>
@@ -76,10 +71,9 @@
 <blockquote>
 <A NAME=23>I am glad to see you in this merry vein:</A><br>
 <A NAME=24>What means this jest? I pray you, master, tell me.</A><br>
-<A NAME=25>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF SYRACUSE</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=26>Yea, dost thou jeer and flout me in the teeth?</A><br>
 <A NAME=27>Think'st thou I jest? Hold, take thou that, and that.</A><br>
@@ -90,10 +84,9 @@
 <blockquote>
 <A NAME=28>Hold, sir, for God's sake! now your jest is earnest:</A><br>
 <A NAME=29>Upon what bargain do you give it me?</A><br>
-<A NAME=30>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF SYRACUSE</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=31>Because that I familiarly sometimes</A><br>
 <A NAME=32>Do use you for my fool and chat with you,</A><br>
@@ -113,10 +106,9 @@
 <A NAME=42>long, I must get a sconce for my head and ensconce</A><br>
 <A NAME=43>it too; or else I shall seek my wit in my shoulders.</A><br>
 <A NAME=44>But, I pray, sir why am I beaten?</A><br>
-<A NAME=45>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech11><b>OF SYRACUSE</b></a>
+<A NAME=speech11><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=46>Dost thou not know?</A><br>
 </blockquote>
@@ -124,10 +116,9 @@
 <A NAME=speech12><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=47>Nothing, sir, but that I am beaten.</A><br>
-<A NAME=48>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech13><b>OF SYRACUSE</b></a>
+<A NAME=speech13><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=49>Shall I tell you why?</A><br>
 </blockquote>
@@ -136,10 +127,9 @@
 <blockquote>
 <A NAME=50>Ay, sir, and wherefore; for they say every why hath</A><br>
 <A NAME=51>a wherefore.</A><br>
-<A NAME=52>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech15><b>OF SYRACUSE</b></a>
+<A NAME=speech15><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=53>Why, first,--for flouting me; and then, wherefore--</A><br>
 <A NAME=54>For urging it the second time to me.</A><br>
@@ -151,10 +141,9 @@
 <A NAME=56>When in the why and the wherefore is neither rhyme</A><br>
 <A NAME=57>nor reason?</A><br>
 <A NAME=58>Well, sir, I thank you.</A><br>
-<A NAME=59>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech17><b>OF SYRACUSE</b></a>
+<A NAME=speech17><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=60>Thank me, sir, for what?</A><br>
 </blockquote>
@@ -162,10 +151,9 @@
 <A NAME=speech18><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=61>Marry, sir, for this something that you gave me for nothing.</A><br>
-<A NAME=62>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech19><b>OF SYRACUSE</b></a>
+<A NAME=speech19><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=63>I'll make you amends next, to give you nothing for</A><br>
 <A NAME=64>something. But say, sir, is it dinner-time?</A><br>
@@ -174,10 +162,9 @@
 <A NAME=speech20><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=65>No, sir; I think the meat wants that I have.</A><br>
-<A NAME=66>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech21><b>OF SYRACUSE</b></a>
+<A NAME=speech21><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=67>In good time, sir; what's that?</A><br>
 </blockquote>
@@ -185,10 +172,9 @@
 <A NAME=speech22><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=68>Basting.</A><br>
-<A NAME=69>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech23><b>OF SYRACUSE</b></a>
+<A NAME=speech23><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=70>Well, sir, then 'twill be dry.</A><br>
 </blockquote>
@@ -196,10 +182,9 @@
 <A NAME=speech24><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=71>If it be, sir, I pray you, eat none of it.</A><br>
-<A NAME=72>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech25><b>OF SYRACUSE</b></a>
+<A NAME=speech25><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=73>Your reason?</A><br>
 </blockquote>
@@ -208,10 +193,9 @@
 <blockquote>
 <A NAME=74>Lest it make you choleric and purchase me another</A><br>
 <A NAME=75>dry basting.</A><br>
-<A NAME=76>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech27><b>OF SYRACUSE</b></a>
+<A NAME=speech27><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=77>Well, sir, learn to jest in good time: there's a</A><br>
 <A NAME=78>time for all things.</A><br>
@@ -220,10 +204,9 @@
 <A NAME=speech28><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=79>I durst have denied that, before you were so choleric.</A><br>
-<A NAME=80>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech29><b>OF SYRACUSE</b></a>
+<A NAME=speech29><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=81>By what rule, sir?</A><br>
 </blockquote>
@@ -232,10 +215,9 @@
 <blockquote>
 <A NAME=82>Marry, sir, by a rule as plain as the plain bald</A><br>
 <A NAME=83>pate of father Time himself.</A><br>
-<A NAME=84>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech31><b>OF SYRACUSE</b></a>
+<A NAME=speech31><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=85>Let's hear it.</A><br>
 </blockquote>
@@ -244,10 +226,9 @@
 <blockquote>
 <A NAME=86>There's no time for a man to recover his hair that</A><br>
 <A NAME=87>grows bald by nature.</A><br>
-<A NAME=88>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech33><b>OF SYRACUSE</b></a>
+<A NAME=speech33><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=89>May he not do it by fine and recovery?</A><br>
 </blockquote>
@@ -256,10 +237,9 @@
 <blockquote>
 <A NAME=90>Yes, to pay a fine for a periwig and recover the</A><br>
 <A NAME=91>lost hair of another man.</A><br>
-<A NAME=92>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech35><b>OF SYRACUSE</b></a>
+<A NAME=speech35><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=93>Why is Time such a niggard of hair, being, as it is,</A><br>
 <A NAME=94>so plentiful an excrement?</A><br>
@@ -269,10 +249,9 @@
 <blockquote>
 <A NAME=95>Because it is a blessing that he bestows on beasts;</A><br>
 <A NAME=96>and what he hath scanted men in hair he hath given them in wit.</A><br>
-<A NAME=97>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech37><b>OF SYRACUSE</b></a>
+<A NAME=speech37><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=98>Why, but there's many a man hath more hair than wit.</A><br>
 </blockquote>
@@ -280,10 +259,9 @@
 <A NAME=speech38><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=99>Not a man of those but he hath the wit to lose his hair.</A><br>
-<A NAME=100>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech39><b>OF SYRACUSE</b></a>
+<A NAME=speech39><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=101>Why, thou didst conclude hairy men plain dealers without wit.</A><br>
 </blockquote>
@@ -292,10 +270,9 @@
 <blockquote>
 <A NAME=102>The plainer dealer, the sooner lost: yet he loseth</A><br>
 <A NAME=103>it in a kind of jollity.</A><br>
-<A NAME=104>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech41><b>OF SYRACUSE</b></a>
+<A NAME=speech41><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=105>For what reason?</A><br>
 </blockquote>
@@ -303,10 +280,9 @@
 <A NAME=speech42><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=106>For two; and sound ones too.</A><br>
-<A NAME=107>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech43><b>OF SYRACUSE</b></a>
+<A NAME=speech43><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=108>Nay, not sound, I pray you.</A><br>
 </blockquote>
@@ -314,10 +290,9 @@
 <A NAME=speech44><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=109>Sure ones, then.</A><br>
-<A NAME=110>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech45><b>OF SYRACUSE</b></a>
+<A NAME=speech45><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=111>Nay, not sure, in a thing falsing.</A><br>
 </blockquote>
@@ -325,10 +300,9 @@
 <A NAME=speech46><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=112>Certain ones then.</A><br>
-<A NAME=113>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech47><b>OF SYRACUSE</b></a>
+<A NAME=speech47><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=114>Name them.</A><br>
 </blockquote>
@@ -338,10 +312,9 @@
 <A NAME=115>The one, to save the money that he spends in</A><br>
 <A NAME=116>trimming; the other, that at dinner they should not</A><br>
 <A NAME=117>drop in his porridge.</A><br>
-<A NAME=118>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech49><b>OF SYRACUSE</b></a>
+<A NAME=speech49><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=119>You would all this time have proved there is no</A><br>
 <A NAME=120>time for all things.</A><br>
@@ -351,10 +324,9 @@
 <blockquote>
 <A NAME=121>Marry, and did, sir; namely, no time to recover hair</A><br>
 <A NAME=122>lost by nature.</A><br>
-<A NAME=123>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech51><b>OF SYRACUSE</b></a>
+<A NAME=speech51><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=124>But your reason was not substantial, why there is no</A><br>
 <A NAME=125>time to recover.</A><br>
@@ -364,10 +336,9 @@
 <blockquote>
 <A NAME=126>Thus I mend it: Time himself is bald and therefore</A><br>
 <A NAME=127>to the world's end will have bald followers.</A><br>
-<A NAME=128>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech53><b>OF SYRACUSE</b></a>
+<A NAME=speech53><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=129>I knew 'twould be a bald conclusion:</A><br>
 <A NAME=130>But, soft! who wafts us yonder?</A><br>
@@ -413,10 +384,9 @@
 <A NAME=165>Being strumpeted by thy contagion.</A><br>
 <A NAME=166>Keep then far league and truce with thy true bed;</A><br>
 <A NAME=167>I live unstain'd, thou undishonoured.</A><br>
-<A NAME=168>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech55><b>OF SYRACUSE</b></a>
+<A NAME=speech55><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=169>Plead you to me, fair dame? I know you not:</A><br>
 <A NAME=170>In Ephesus I am but two hours old,</A><br>
@@ -430,10 +400,9 @@
 <A NAME=174>Fie, brother! how the world is changed with you!</A><br>
 <A NAME=175>When were you wont to use my sister thus?</A><br>
 <A NAME=176>She sent for you by Dromio home to dinner.</A><br>
-<A NAME=177>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech57><b>OF SYRACUSE</b></a>
+<A NAME=speech57><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=178>By Dromio?</A><br>
 </blockquote>
@@ -448,10 +417,9 @@
 <A NAME=180>By thee; and this thou didst return from him,</A><br>
 <A NAME=181>That he did buffet thee, and, in his blows,</A><br>
 <A NAME=182>Denied my house for his, me for his wife.</A><br>
-<A NAME=183>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech60><b>OF SYRACUSE</b></a>
+<A NAME=speech60><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=184>Did you converse, sir, with this gentlewoman?</A><br>
 <A NAME=185>What is the course and drift of your compact?</A><br>
@@ -460,10 +428,9 @@
 <A NAME=speech61><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=186>I, sir? I never saw her till this time.</A><br>
-<A NAME=187>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech62><b>OF SYRACUSE</b></a>
+<A NAME=speech62><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=188>Villain, thou liest; for even her very words</A><br>
 <A NAME=189>Didst thou deliver to me on the mart.</A><br>
@@ -472,10 +439,9 @@
 <A NAME=speech63><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=190>I never spake with her in all my life.</A><br>
-<A NAME=191>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech64><b>OF SYRACUSE</b></a>
+<A NAME=speech64><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=192>How can she thus then call us by our names,</A><br>
 <A NAME=193>Unless it be by inspiration.</A><br>
@@ -496,10 +462,9 @@
 <A NAME=204>Usurping ivy, brier, or idle moss;</A><br>
 <A NAME=205>Who, all for want of pruning, with intrusion</A><br>
 <A NAME=206>Infect thy sap and live on thy confusion.</A><br>
-<A NAME=207>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech66><b>OF SYRACUSE</b></a>
+<A NAME=speech66><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=208>To me she speaks; she moves me for her theme:</A><br>
 <A NAME=209>What, was I married to her in my dream?</A><br>
@@ -532,10 +497,9 @@
 <A NAME=speech70><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=222>I am transformed, master, am I not?</A><br>
-<A NAME=223>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech71><b>OF SYRACUSE</b></a>
+<A NAME=speech71><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=224>I think thou art in mind, and so am I.</A><br>
 </blockquote>
@@ -543,10 +507,9 @@
 <A NAME=speech72><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=225>Nay, master, both in mind and in my shape.</A><br>
-<A NAME=226>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech73><b>OF SYRACUSE</b></a>
+<A NAME=speech73><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=227>Thou hast thine own form.</A><br>
 </blockquote>
@@ -579,10 +542,9 @@
 <A NAME=239>Sirrah, if any ask you for your master,</A><br>
 <A NAME=240>Say he dines forth, and let no creature enter.</A><br>
 <A NAME=241>Come, sister. Dromio, play the porter well.</A><br>
-<A NAME=242>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech78><b>OF SYRACUSE</b></a>
+<A NAME=speech78><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=243>Am I in earth, in heaven, or in hell?</A><br>
 <A NAME=244>Sleeping or waking? mad or well-advised?</A><br>

--- a/comedy_errors/comedy_errors.3.1.html
+++ b/comedy_errors/comedy_errors.3.1.html
@@ -207,10 +207,9 @@
 <A NAME=77>answered him well.</A><br>
 </blockquote>
 
-<A NAME=speech29><b>ANTIPHOLUS</b></a>
+<A NAME=speech29><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=78>Do you hear, you minion? you'll let us in, I hope?</A><br>
-<A NAME=79>OF EPHESUS</A><br>
 </blockquote>
 
 <A NAME=speech30><b>LUCE</b></a>

--- a/comedy_errors/comedy_errors.3.1.html
+++ b/comedy_errors/comedy_errors.3.1.html
@@ -26,11 +26,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Ephesus, DROMIO of Ephesus, ANGELO, and BALTHAZAR</i>
 </blockquote>
-<blockquote>
-<A NAME=1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF EPHESUS</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=2>Good Signior Angelo, you must excuse us all;</A><br>
 <A NAME=3>My wife is shrewish when I keep not hours:</A><br>
@@ -50,10 +47,9 @@
 <A NAME=13>That you beat me at the mart, I have your hand to show:</A><br>
 <A NAME=14>If the skin were parchment, and the blows you gave were ink,</A><br>
 <A NAME=15>Your own handwriting would tell you what I think.</A><br>
-<A NAME=16>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF EPHESUS</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=17>I think thou art an ass.</A><br>
 </blockquote>
@@ -64,10 +60,9 @@
 <A NAME=19>By the wrongs I suffer and the blows I bear.</A><br>
 <A NAME=20>I should kick, being kick'd; and, being at that pass,</A><br>
 <A NAME=21>You would keep from my heels and beware of an ass.</A><br>
-<A NAME=22>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF EPHESUS</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=23>You're sad, Signior Balthazar: pray God our cheer</A><br>
 <A NAME=24>May answer my good will and your good welcome here.</A><br>
@@ -77,10 +72,9 @@
 <blockquote>
 <A NAME=25>I hold your dainties cheap, sir, and your</A><br>
 <A NAME=26>welcome dear.</A><br>
-<A NAME=27>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF EPHESUS</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=28>O, Signior Balthazar, either at flesh or fish,</A><br>
 <A NAME=29>A table full of welcome make scarce one dainty dish.</A><br>
@@ -89,10 +83,9 @@
 <A NAME=speech8><b>BALTHAZAR</b></a>
 <blockquote>
 <A NAME=30>Good meat, sir, is common; that every churl affords.</A><br>
-<A NAME=31>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF EPHESUS</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=32>And welcome more common; for that's nothing but words.</A><br>
 </blockquote>
@@ -100,10 +93,9 @@
 <A NAME=speech10><b>BALTHAZAR</b></a>
 <blockquote>
 <A NAME=33>Small cheer and great welcome makes a merry feast.</A><br>
-<A NAME=34>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech11><b>OF EPHESUS</b></a>
+<A NAME=speech11><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=35>Ay, to a niggardly host, and more sparing guest:</A><br>
 <A NAME=36>But though my cates be mean, take them in good part;</A><br>
@@ -136,10 +128,9 @@
 <blockquote>
 <A NAME=48>[Within]  Let him walk from whence he came, lest he</A><br>
 <A NAME=49>catch cold on's feet.</A><br>
-<A NAME=50>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech16><b>OF EPHESUS</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=51>Who talks within there? ho, open the door!</A><br>
 </blockquote>
@@ -148,10 +139,9 @@
 <blockquote>
 <A NAME=52>[Within]  Right, sir; I'll tell you when, an you tell</A><br>
 <A NAME=53>me wherefore.</A><br>
-<A NAME=54>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF EPHESUS</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=55>Wherefore? for my dinner: I have not dined to-day.</A><br>
 </blockquote>
@@ -160,10 +150,9 @@
 <blockquote>
 <A NAME=56>[Within]  Nor to-day here you must not; come again</A><br>
 <A NAME=57>when you may.</A><br>
-<A NAME=58>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech20><b>OF EPHESUS</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=59>What art thou that keepest me out from the house I owe?</A><br>
 </blockquote>
@@ -237,10 +226,9 @@
 <A NAME=speech32><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=82>So, come, help: well struck! there was blow for blow.</A><br>
-<A NAME=83>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech33><b>OF EPHESUS</b></a>
+<A NAME=speech33><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=84>Thou baggage, let me in.</A><br>
 </blockquote>
@@ -258,10 +246,9 @@
 <A NAME=speech36><b>LUCE</b></a>
 <blockquote>
 <A NAME=87>[Within]  Let him knock till it ache.</A><br>
-<A NAME=88>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech37><b>OF EPHESUS</b></a>
+<A NAME=speech37><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=89>You'll cry for this, minion, if I beat the door down.</A><br>
 </blockquote>
@@ -281,10 +268,9 @@
 <blockquote>
 <A NAME=93>[Within]  By my troth, your town is troubled with</A><br>
 <A NAME=94>unruly boys.</A><br>
-<A NAME=95>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech41><b>OF EPHESUS</b></a>
+<A NAME=speech41><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=96>Are you there, wife? you might have come before.</A><br>
 </blockquote>
@@ -313,10 +299,9 @@
 <A NAME=speech46><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=102>They stand at the door, master; bid them welcome hither.</A><br>
-<A NAME=103>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech47><b>OF EPHESUS</b></a>
+<A NAME=speech47><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=104>There is something in the wind, that we cannot get in.</A><br>
 </blockquote>
@@ -326,10 +311,9 @@
 <A NAME=105>You would say so, master, if your garments were thin.</A><br>
 <A NAME=106>Your cake there is warm within; you stand here in the cold:</A><br>
 <A NAME=107>It would make a man mad as a buck, to be so bought and sold.</A><br>
-<A NAME=108>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech49><b>OF EPHESUS</b></a>
+<A NAME=speech49><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=109>Go fetch me something: I'll break ope the gate.</A><br>
 </blockquote>
@@ -361,10 +345,9 @@
 <A NAME=speech54><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=118>[Within]  Ay, when fowls have no feathers and fish have no fin.</A><br>
-<A NAME=119>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech55><b>OF EPHESUS</b></a>
+<A NAME=speech55><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=120>Well, I'll break in: go borrow me a crow.</A><br>
 </blockquote>
@@ -374,10 +357,9 @@
 <A NAME=121>A crow without feather? Master, mean you so?</A><br>
 <A NAME=122>For a fish without a fin, there's a fowl without a feather;</A><br>
 <A NAME=123>If a crow help us in, sirrah, we'll pluck a crow together.</A><br>
-<A NAME=124>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech57><b>OF EPHESUS</b></a>
+<A NAME=speech57><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=125>Go get thee gone; fetch me an iron crow.</A><br>
 </blockquote>
@@ -406,10 +388,9 @@
 <A NAME=145>And dwell upon your grave when you are dead;</A><br>
 <A NAME=146>For slander lives upon succession,</A><br>
 <A NAME=147>For ever housed where it gets possession.</A><br>
-<A NAME=148>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech59><b>OF EPHESUS</b></a>
+<A NAME=speech59><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=149>You have prevailed: I will depart in quiet,</A><br>
 <A NAME=150>And, in despite of mirth, mean to be merry.</A><br>
@@ -433,10 +414,9 @@
 <A NAME=speech60><b>ANGELO</b></a>
 <blockquote>
 <A NAME=165>I'll meet you at that place some hour hence.</A><br>
-<A NAME=166>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech61><b>OF EPHESUS</b></a>
+<A NAME=speech61><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=167>Do so. This jest shall cost me some expense.</A><br>
 <p><i>Exeunt</i></p>

--- a/comedy_errors/comedy_errors.3.2.html
+++ b/comedy_errors/comedy_errors.3.2.html
@@ -183,7 +183,7 @@
 <A NAME=87>I am an ass, I am a woman's man and besides myself.</A><br>
 </blockquote>
 
-<A NAME=speech20><b>ANTIPHOLUS</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=88>What woman's man? and how besides thyself? besides thyself?</A><br>
 </blockquote>

--- a/comedy_errors/comedy_errors.3.2.html
+++ b/comedy_errors/comedy_errors.3.2.html
@@ -57,10 +57,9 @@
 <A NAME=26>Comfort my sister, cheer her, call her wife:</A><br>
 <A NAME=27>'Tis holy sport to be a little vain,</A><br>
 <A NAME=28>When the sweet breath of flattery conquers strife.</A><br>
-<A NAME=29>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech2><b>OF SYRACUSE</b></a>
+<A NAME=speech2><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=30>Sweet mistress--what your name is else, I know not,</A><br>
 <A NAME=31>Nor by what wonder you do hit of mine,--</A><br>
@@ -91,10 +90,9 @@
 <A NAME=speech3><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=54>What, are you mad, that you do reason so?</A><br>
-<A NAME=55>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech4><b>OF SYRACUSE</b></a>
+<A NAME=speech4><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=56>Not mad, but mated; how, I do not know.</A><br>
 </blockquote>
@@ -102,10 +100,9 @@
 <A NAME=speech5><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=57>It is a fault that springeth from your eye.</A><br>
-<A NAME=58>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF SYRACUSE</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=59>For gazing on your beams, fair sun, being by.</A><br>
 </blockquote>
@@ -113,10 +110,9 @@
 <A NAME=speech7><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=60>Gaze where you should, and that will clear your sight.</A><br>
-<A NAME=61>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF SYRACUSE</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=62>As good to wink, sweet love, as look on night.</A><br>
 </blockquote>
@@ -124,10 +120,9 @@
 <A NAME=speech9><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=63>Why call you me love? call my sister so.</A><br>
-<A NAME=64>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF SYRACUSE</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=65>Thy sister's sister.</A><br>
 </blockquote>
@@ -135,10 +130,9 @@
 <A NAME=speech11><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=66>That's my sister.</A><br>
-<A NAME=67>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech12><b>OF SYRACUSE</b></a>
+<A NAME=speech12><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=68>No;</A><br>
 <A NAME=69>It is thyself, mine own self's better part,</A><br>
@@ -150,10 +144,9 @@
 <A NAME=speech13><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=73>All this my sister is, or else should be.</A><br>
-<A NAME=74>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF SYRACUSE</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=75>Call thyself sister, sweet, for I am thee.</A><br>
 <A NAME=76>Thee will I love and with thee lead my life:</A><br>
@@ -167,10 +160,9 @@
 <A NAME=80>I'll fetch my sister, to get her good will.</A><br>
 <p><i>Exit</i></p>
 <p><i>Enter DROMIO of Syracuse</i></p>
-<A NAME=81>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech16><b>OF SYRACUSE</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=82>Why, how now, Dromio! where runn'st thou so fast?</A><br>
 </blockquote>
@@ -179,10 +171,9 @@
 <blockquote>
 <A NAME=83>Do you know me, sir? am I Dromio? am I your man?</A><br>
 <A NAME=84>am I myself?</A><br>
-<A NAME=85>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF SYRACUSE</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=86>Thou art Dromio, thou art my man, thou art thyself.</A><br>
 </blockquote>
@@ -201,10 +192,9 @@
 <blockquote>
 <A NAME=89>Marry, sir, besides myself, I am due to a woman; one</A><br>
 <A NAME=90>that claims me, one that haunts me, one that will have me.</A><br>
-<A NAME=91>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech22><b>OF SYRACUSE</b></a>
+<A NAME=speech22><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=92>What claim lays she to thee?</A><br>
 </blockquote>
@@ -215,10 +205,9 @@
 <A NAME=94>horse; and she would have me as a beast: not that, I</A><br>
 <A NAME=95>being a beast, she would have me; but that she,</A><br>
 <A NAME=96>being a very beastly creature, lays claim to me.</A><br>
-<A NAME=97>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech24><b>OF SYRACUSE</b></a>
+<A NAME=speech24><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=98>What is she?</A><br>
 </blockquote>
@@ -229,10 +218,9 @@
 <A NAME=100>not speak of without he say 'Sir-reverence.' I have</A><br>
 <A NAME=101>but lean luck in the match, and yet is she a</A><br>
 <A NAME=102>wondrous fat marriage.</A><br>
-<A NAME=103>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech26><b>OF SYRACUSE</b></a>
+<A NAME=speech26><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=104>How dost thou mean a fat marriage?</A><br>
 </blockquote>
@@ -245,10 +233,9 @@
 <A NAME=108>warrant, her rags and the tallow in them will burn a</A><br>
 <A NAME=109>Poland winter: if she lives till doomsday,</A><br>
 <A NAME=110>she'll burn a week longer than the whole world.</A><br>
-<A NAME=111>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech28><b>OF SYRACUSE</b></a>
+<A NAME=speech28><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=112>What complexion is she of?</A><br>
 </blockquote>
@@ -258,10 +245,9 @@
 <A NAME=113>Swart, like my shoe, but her face nothing half so</A><br>
 <A NAME=114>clean kept: for why, she sweats; a man may go over</A><br>
 <A NAME=115>shoes in the grime of it.</A><br>
-<A NAME=116>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech30><b>OF SYRACUSE</b></a>
+<A NAME=speech30><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=117>That's a fault that water will mend.</A><br>
 </blockquote>
@@ -269,10 +255,9 @@
 <A NAME=speech31><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=118>No, sir, 'tis in grain; Noah's flood could not do it.</A><br>
-<A NAME=119>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech32><b>OF SYRACUSE</b></a>
+<A NAME=speech32><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=120>What's her name?</A><br>
 </blockquote>
@@ -282,10 +267,9 @@
 <A NAME=121>Nell, sir; but her name and three quarters, that's</A><br>
 <A NAME=122>an ell and three quarters, will not measure her from</A><br>
 <A NAME=123>hip to hip.</A><br>
-<A NAME=124>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech34><b>OF SYRACUSE</b></a>
+<A NAME=speech34><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=125>Then she bears some breadth?</A><br>
 </blockquote>
@@ -295,10 +279,9 @@
 <A NAME=126>No longer from head to foot than from hip to hip:</A><br>
 <A NAME=127>she is spherical, like a globe; I could find out</A><br>
 <A NAME=128>countries in her.</A><br>
-<A NAME=129>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech36><b>OF SYRACUSE</b></a>
+<A NAME=speech36><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=130>In what part of her body stands Ireland?</A><br>
 </blockquote>
@@ -306,10 +289,9 @@
 <A NAME=speech37><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=131>Marry, in her buttocks: I found it out by the bogs.</A><br>
-<A NAME=132>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech38><b>OF SYRACUSE</b></a>
+<A NAME=speech38><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=133>Where Scotland?</A><br>
 </blockquote>
@@ -317,10 +299,9 @@
 <A NAME=speech39><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=134>I found it by the barrenness; hard in the palm of the hand.</A><br>
-<A NAME=135>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech40><b>OF SYRACUSE</b></a>
+<A NAME=speech40><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=136>Where France?</A><br>
 </blockquote>
@@ -329,10 +310,9 @@
 <blockquote>
 <A NAME=137>In her forehead; armed and reverted, making war</A><br>
 <A NAME=138>against her heir.</A><br>
-<A NAME=139>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech42><b>OF SYRACUSE</b></a>
+<A NAME=speech42><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=140>Where England?</A><br>
 </blockquote>
@@ -342,10 +322,9 @@
 <A NAME=141>I looked for the chalky cliffs, but I could find no</A><br>
 <A NAME=142>whiteness in them; but I guess it stood in her chin,</A><br>
 <A NAME=143>by the salt rheum that ran between France and it.</A><br>
-<A NAME=144>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech44><b>OF SYRACUSE</b></a>
+<A NAME=speech44><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=145>Where Spain?</A><br>
 </blockquote>
@@ -353,10 +332,9 @@
 <A NAME=speech45><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=146>Faith, I saw it not; but I felt it hot in her breath.</A><br>
-<A NAME=147>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech46><b>OF SYRACUSE</b></a>
+<A NAME=speech46><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=148>Where America, the Indies?</A><br>
 </blockquote>
@@ -367,10 +345,9 @@
 <A NAME=150>rubies, carbuncles, sapphires, declining their rich</A><br>
 <A NAME=151>aspect to the hot breath of Spain; who sent whole</A><br>
 <A NAME=152>armadoes of caracks to be ballast at her nose.</A><br>
-<A NAME=153>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech48><b>OF SYRACUSE</b></a>
+<A NAME=speech48><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=154>Where stood Belgia, the Netherlands?</A><br>
 </blockquote>
@@ -387,10 +364,9 @@
 <A NAME=162>faith and my heart of steel,</A><br>
 <A NAME=163>She had transform'd me to a curtal dog and made</A><br>
 <A NAME=164>me turn i' the wheel.</A><br>
-<A NAME=165>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech50><b>OF SYRACUSE</b></a>
+<A NAME=speech50><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=166>Go hie thee presently, post to the road:</A><br>
 <A NAME=167>An if the wind blow any way from shore,</A><br>
@@ -406,10 +382,9 @@
 <A NAME=173>As from a bear a man would run for life,</A><br>
 <A NAME=174>So fly I from her that would be my wife.</A><br>
 <p><i>Exit</i></p>
-<A NAME=175>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech52><b>OF SYRACUSE</b></a>
+<A NAME=speech52><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=176>There's none but witches do inhabit here;</A><br>
 <A NAME=177>And therefore 'tis high time that I were hence.</A><br>
@@ -426,10 +401,9 @@
 <A NAME=speech53><b>ANGELO</b></a>
 <blockquote>
 <A NAME=185>Master Antipholus,--</A><br>
-<A NAME=186>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech54><b>OF SYRACUSE</b></a>
+<A NAME=speech54><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=187>Ay, that's my name.</A><br>
 </blockquote>
@@ -439,10 +413,9 @@
 <A NAME=188>I know it well, sir, lo, here is the chain.</A><br>
 <A NAME=189>I thought to have ta'en you at the Porpentine:</A><br>
 <A NAME=190>The chain unfinish'd made me stay thus long.</A><br>
-<A NAME=191>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech56><b>OF SYRACUSE</b></a>
+<A NAME=speech56><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=192>What is your will that I shall do with this?</A><br>
 </blockquote>
@@ -450,10 +423,9 @@
 <A NAME=speech57><b>ANGELO</b></a>
 <blockquote>
 <A NAME=193>What please yourself, sir: I have made it for you.</A><br>
-<A NAME=194>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech58><b>OF SYRACUSE</b></a>
+<A NAME=speech58><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=195>Made it for me, sir! I bespoke it not.</A><br>
 </blockquote>
@@ -464,10 +436,9 @@
 <A NAME=197>Go home with it and please your wife withal;</A><br>
 <A NAME=198>And soon at supper-time I'll visit you</A><br>
 <A NAME=199>And then receive my money for the chain.</A><br>
-<A NAME=200>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech60><b>OF SYRACUSE</b></a>
+<A NAME=speech60><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=201>I pray you, sir, receive the money now,</A><br>
 <A NAME=202>For fear you ne'er see chain nor money more.</A><br>
@@ -477,10 +448,9 @@
 <blockquote>
 <A NAME=203>You are a merry man, sir: fare you well.</A><br>
 <p><i>Exit</i></p>
-<A NAME=204>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech62><b>OF SYRACUSE</b></a>
+<A NAME=speech62><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=205>What I should think of this, I cannot tell:</A><br>
 <A NAME=206>But this I think, there's no man is so vain</A><br>

--- a/comedy_errors/comedy_errors.4.1.html
+++ b/comedy_errors/comedy_errors.4.1.html
@@ -52,10 +52,9 @@
 <A NAME=speech3><b>Officer</b></a>
 <blockquote>
 <A NAME=14>That labour may you save: see where he comes.</A><br>
-<A NAME=15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech4><b>OF EPHESUS</b></a>
+<A NAME=speech4><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=16>While I go to the goldsmith's house, go thou</A><br>
 <A NAME=17>And buy a rope's end: that will I bestow</A><br>
@@ -69,10 +68,9 @@
 <blockquote>
 <A NAME=22>I buy a thousand pound a year: I buy a rope.</A><br>
 <p><i>Exit</i></p>
-<A NAME=23>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF EPHESUS</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=24>A man is well holp up that trusts to you:</A><br>
 <A NAME=25>I promised your presence and the chain;</A><br>
@@ -90,10 +88,9 @@
 <A NAME=33>Than I stand debted to this gentleman:</A><br>
 <A NAME=34>I pray you, see him presently discharged,</A><br>
 <A NAME=35>For he is bound to sea and stays but for it.</A><br>
-<A NAME=36>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF EPHESUS</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=37>I am not furnish'd with the present money;</A><br>
 <A NAME=38>Besides, I have some business in the town.</A><br>
@@ -106,10 +103,9 @@
 <A NAME=speech9><b>ANGELO</b></a>
 <blockquote>
 <A NAME=43>Then you will bring the chain to her yourself?</A><br>
-<A NAME=44>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF EPHESUS</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=45>No; bear it with you, lest I come not time enough.</A><br>
 </blockquote>
@@ -117,10 +113,9 @@
 <A NAME=speech11><b>ANGELO</b></a>
 <blockquote>
 <A NAME=46>Well, sir, I will. Have you the chain about you?</A><br>
-<A NAME=47>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech12><b>OF EPHESUS</b></a>
+<A NAME=speech12><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=48>An if I have not, sir, I hope you have;</A><br>
 <A NAME=49>Or else you may return without your money.</A><br>
@@ -131,10 +126,9 @@
 <A NAME=50>Nay, come, I pray you, sir, give me the chain:</A><br>
 <A NAME=51>Both wind and tide stays for this gentleman,</A><br>
 <A NAME=52>And I, to blame, have held him here too long.</A><br>
-<A NAME=53>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF EPHESUS</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=54>Good Lord! you use this dalliance to excuse</A><br>
 <A NAME=55>Your breach of promise to the Porpentine.</A><br>
@@ -150,10 +144,9 @@
 <A NAME=speech16><b>ANGELO</b></a>
 <blockquote>
 <A NAME=59>You hear how he importunes me;--the chain!</A><br>
-<A NAME=60>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech17><b>OF EPHESUS</b></a>
+<A NAME=speech17><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=61>Why, give it to my wife and fetch your money.</A><br>
 </blockquote>
@@ -162,10 +155,9 @@
 <blockquote>
 <A NAME=62>Come, come, you know I gave it you even now.</A><br>
 <A NAME=63>Either send the chain or send me by some token.</A><br>
-<A NAME=64>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech19><b>OF EPHESUS</b></a>
+<A NAME=speech19><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=65>Fie, now you run this humour out of breath,</A><br>
 <A NAME=66>where's the chain? I pray you, let me see it.</A><br>
@@ -176,10 +168,9 @@
 <A NAME=67>My business cannot brook this dalliance.</A><br>
 <A NAME=68>Good sir, say whether you'll answer me or no:</A><br>
 <A NAME=69>If not, I'll leave him to the officer.</A><br>
-<A NAME=70>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech21><b>OF EPHESUS</b></a>
+<A NAME=speech21><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=71>I answer you! what should I answer you?</A><br>
 </blockquote>
@@ -187,10 +178,9 @@
 <A NAME=speech22><b>ANGELO</b></a>
 <blockquote>
 <A NAME=72>The money that you owe me for the chain.</A><br>
-<A NAME=73>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech23><b>OF EPHESUS</b></a>
+<A NAME=speech23><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=74>I owe you none till I receive the chain.</A><br>
 </blockquote>
@@ -198,10 +188,9 @@
 <A NAME=speech24><b>ANGELO</b></a>
 <blockquote>
 <A NAME=75>You know I gave it you half an hour since.</A><br>
-<A NAME=76>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech25><b>OF EPHESUS</b></a>
+<A NAME=speech25><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=77>You gave me none: you wrong me much to say so.</A><br>
 </blockquote>
@@ -227,10 +216,9 @@
 <A NAME=82>This touches me in reputation.</A><br>
 <A NAME=83>Either consent to pay this sum for me</A><br>
 <A NAME=84>Or I attach you by this officer.</A><br>
-<A NAME=85>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech30><b>OF EPHESUS</b></a>
+<A NAME=speech30><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=86>Consent to pay thee that I never had!</A><br>
 <A NAME=87>Arrest me, foolish fellow, if thou darest.</A><br>
@@ -246,10 +234,9 @@
 <A NAME=speech32><b>Officer</b></a>
 <blockquote>
 <A NAME=91>I do arrest you, sir: you hear the suit.</A><br>
-<A NAME=92>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech33><b>OF EPHESUS</b></a>
+<A NAME=speech33><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=93>I do obey thee till I give thee bail.</A><br>
 <A NAME=94>But, sirrah, you shall buy this sport as dear</A><br>
@@ -273,10 +260,9 @@
 <A NAME=103>The ship is in her trim; the merry wind</A><br>
 <A NAME=104>Blows fair from land: they stay for nought at all</A><br>
 <A NAME=105>But for their owner, master, and yourself.</A><br>
-<A NAME=106>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech36><b>OF EPHESUS</b></a>
+<A NAME=speech36><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=107>How now! a madman! Why, thou peevish sheep,</A><br>
 <A NAME=108>What ship of Epidamnum stays for me?</A><br>
@@ -285,10 +271,9 @@
 <A NAME=speech37><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=109>A ship you sent me to, to hire waftage.</A><br>
-<A NAME=110>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech38><b>OF EPHESUS</b></a>
+<A NAME=speech38><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=111>Thou drunken slave, I sent thee for a rope;</A><br>
 <A NAME=112>And told thee to what purpose and what end.</A><br>
@@ -298,10 +283,9 @@
 <blockquote>
 <A NAME=113>You sent me for a rope's end as soon:</A><br>
 <A NAME=114>You sent me to the bay, sir, for a bark.</A><br>
-<A NAME=115>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech40><b>OF EPHESUS</b></a>
+<A NAME=speech40><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=116>I will debate this matter at more leisure</A><br>
 <A NAME=117>And teach your ears to list me with more heed.</A><br>

--- a/comedy_errors/comedy_errors.4.4.html
+++ b/comedy_errors/comedy_errors.4.4.html
@@ -113,7 +113,7 @@
 <A NAME=30>your blows.</A><br>
 </blockquote>
 
-<A NAME=speech16><b>ANTIPHOLUS</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=31>Thou art sensible in nothing but blows, and so is an</A><br>
 <A NAME=32>ass.</A><br>

--- a/comedy_errors/comedy_errors.4.4.html
+++ b/comedy_errors/comedy_errors.4.4.html
@@ -26,11 +26,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Ephesus and the Officer</i>
 </blockquote>
-<blockquote>
-<A NAME=1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF EPHESUS</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=2>Fear me not, man; I will not break away:</A><br>
 <A NAME=3>I'll give thee, ere I leave thee, so much money,</A><br>
@@ -47,10 +44,9 @@
 <A NAME=speech2><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=11>Here's that, I warrant you, will pay them all.</A><br>
-<A NAME=12>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF EPHESUS</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=13>But where's the money?</A><br>
 </blockquote>
@@ -58,10 +54,9 @@
 <A NAME=speech4><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=14>Why, sir, I gave the money for the rope.</A><br>
-<A NAME=15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF EPHESUS</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=16>Five hundred ducats, villain, for a rope?</A><br>
 </blockquote>
@@ -69,10 +64,9 @@
 <A NAME=speech6><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=17>I'll serve you, sir, five hundred at the rate.</A><br>
-<A NAME=18>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF EPHESUS</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=19>To what end did I bid thee hie thee home?</A><br>
 </blockquote>
@@ -80,10 +74,9 @@
 <A NAME=speech8><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=20>To a rope's-end, sir; and to that end am I returned.</A><br>
-<A NAME=21>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF EPHESUS</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=22>And to that end, sir, I will welcome you.</A><br>
 <p><i>Beating him</i></p>
@@ -107,10 +100,9 @@
 <A NAME=speech13><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=26>Nay, rather persuade him to hold his hands.</A><br>
-<A NAME=27>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF EPHESUS</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=28>Thou whoreson, senseless villain!</A><br>
 </blockquote>
@@ -140,10 +132,9 @@
 <A NAME=41>I return; nay, I bear it on my shoulders, as a</A><br>
 <A NAME=42>beggar wont her brat; and, I think when he hath</A><br>
 <A NAME=43>lamed me, I shall beg with it from door to door.</A><br>
-<A NAME=44>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF EPHESUS</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=45>Come, go along; my wife is coming yonder.</A><br>
 <p><i>Enter ADRIANA, LUCIANA, the Courtezan, and PINCH</i></p>
@@ -154,10 +145,9 @@
 <A NAME=46>Mistress, 'respice finem,' respect your end; or</A><br>
 <A NAME=47>rather, the prophecy like the parrot, 'beware the</A><br>
 <A NAME=48>rope's-end.'</A><br>
-<A NAME=49>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech20><b>OF EPHESUS</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=50>Wilt thou still talk?</A><br>
 <p><i>Beating him</i></p>
@@ -189,10 +179,9 @@
 <A NAME=speech25><b>PINCH</b></a>
 <blockquote>
 <A NAME=58>Give me your hand and let me feel your pulse.</A><br>
-<A NAME=59>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech26><b>OF EPHESUS</b></a>
+<A NAME=speech26><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=60>There is my hand, and let it feel your ear.</A><br>
 <p><i>Striking him</i></p>
@@ -204,10 +193,9 @@
 <A NAME=62>To yield possession to my holy prayers</A><br>
 <A NAME=63>And to thy state of darkness hie thee straight:</A><br>
 <A NAME=64>I conjure thee by all the saints in heaven!</A><br>
-<A NAME=65>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech28><b>OF EPHESUS</b></a>
+<A NAME=speech28><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=66>Peace, doting wizard, peace! I am not mad.</A><br>
 </blockquote>
@@ -215,10 +203,9 @@
 <A NAME=speech29><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=67>O, that thou wert not, poor distressed soul!</A><br>
-<A NAME=68>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech30><b>OF EPHESUS</b></a>
+<A NAME=speech30><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=69>You minion, you, are these your customers?</A><br>
 <A NAME=70>Did this companion with the saffron face</A><br>
@@ -232,10 +219,9 @@
 <A NAME=74>O husband, God doth know you dined at home;</A><br>
 <A NAME=75>Where would you had remain'd until this time,</A><br>
 <A NAME=76>Free from these slanders and this open shame!</A><br>
-<A NAME=77>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech32><b>OF EPHESUS</b></a>
+<A NAME=speech32><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=78>Dined at home! Thou villain, what sayest thou?</A><br>
 </blockquote>
@@ -243,10 +229,9 @@
 <A NAME=speech33><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=79>Sir, sooth to say, you did not dine at home.</A><br>
-<A NAME=80>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech34><b>OF EPHESUS</b></a>
+<A NAME=speech34><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=81>Were not my doors lock'd up and I shut out?</A><br>
 </blockquote>
@@ -254,10 +239,9 @@
 <A NAME=speech35><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=82>Perdie, your doors were lock'd and you shut out.</A><br>
-<A NAME=83>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech36><b>OF EPHESUS</b></a>
+<A NAME=speech36><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=84>And did not she herself revile me there?</A><br>
 </blockquote>
@@ -265,10 +249,9 @@
 <A NAME=speech37><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=85>Sans fable, she herself reviled you there.</A><br>
-<A NAME=86>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech38><b>OF EPHESUS</b></a>
+<A NAME=speech38><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=87>Did not her kitchen-maid rail, taunt, and scorn me?</A><br>
 </blockquote>
@@ -276,10 +259,9 @@
 <A NAME=speech39><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=88>Certes, she did; the kitchen-vestal scorn'd you.</A><br>
-<A NAME=89>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech40><b>OF EPHESUS</b></a>
+<A NAME=speech40><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=90>And did not I in rage depart from thence?</A><br>
 </blockquote>
@@ -299,10 +281,9 @@
 <blockquote>
 <A NAME=94>It is no shame: the fellow finds his vein,</A><br>
 <A NAME=95>And yielding to him humours well his frenzy.</A><br>
-<A NAME=96>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech44><b>OF EPHESUS</b></a>
+<A NAME=speech44><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=97>Thou hast suborn'd the goldsmith to arrest me.</A><br>
 </blockquote>
@@ -317,10 +298,9 @@
 <blockquote>
 <A NAME=100>Money by me! heart and goodwill you might;</A><br>
 <A NAME=101>But surely master, not a rag of money.</A><br>
-<A NAME=102>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech47><b>OF EPHESUS</b></a>
+<A NAME=speech47><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=103>Went'st not thou to her for a purse of ducats?</A><br>
 </blockquote>
@@ -346,10 +326,9 @@
 <A NAME=108>Mistress, both man and master is possess'd;</A><br>
 <A NAME=109>I know it by their pale and deadly looks:</A><br>
 <A NAME=110>They must be bound and laid in some dark room.</A><br>
-<A NAME=111>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech52><b>OF EPHESUS</b></a>
+<A NAME=speech52><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=112>Say, wherefore didst thou lock me forth to-day?</A><br>
 <A NAME=113>And why dost thou deny the bag of gold?</A><br>
@@ -369,10 +348,9 @@
 <A NAME=speech55><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=117>Dissembling villain, thou speak'st false in both.</A><br>
-<A NAME=118>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech56><b>OF EPHESUS</b></a>
+<A NAME=speech56><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=119>Dissembling harlot, thou art false in all;</A><br>
 <A NAME=120>And art confederate with a damned pack</A><br>
@@ -395,10 +373,9 @@
 <A NAME=speech59><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=126>Ay me, poor man, how pale and wan he looks!</A><br>
-<A NAME=127>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech60><b>OF EPHESUS</b></a>
+<A NAME=speech60><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=128>What, will you murder me? Thou gaoler, thou,</A><br>
 <A NAME=129>I am thy prisoner: wilt thou suffer them</A><br>
@@ -437,10 +414,9 @@
 <A NAME=141>And, knowing how the debt grows, I will pay it.</A><br>
 <A NAME=142>Good master doctor, see him safe convey'd</A><br>
 <A NAME=143>Home to my house. O most unhappy day!</A><br>
-<A NAME=144>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech66><b>OF EPHESUS</b></a>
+<A NAME=speech66><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=145>O most unhappy strumpet!</A><br>
 </blockquote>
@@ -448,10 +424,9 @@
 <A NAME=speech67><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=146>Master, I am here entered in bond for you.</A><br>
-<A NAME=147>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech68><b>OF EPHESUS</b></a>
+<A NAME=speech68><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=148>Out on thee, villain! wherefore dost thou mad me?</A><br>
 </blockquote>
@@ -535,10 +510,9 @@
 <blockquote>
 <A NAME=170>Away! they'll kill us.</A><br>
 <p><i>Exeunt all but Antipholus of Syracuse and Dromio of Syracuse</i></p>
-<A NAME=171>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech83><b>OF SYRACUSE</b></a>
+<A NAME=speech83><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=172>I see these witches are afraid of swords.</A><br>
 </blockquote>
@@ -546,10 +520,9 @@
 <A NAME=speech84><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=173>She that would be your wife now ran from you.</A><br>
-<A NAME=174>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech85><b>OF SYRACUSE</b></a>
+<A NAME=speech85><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=175>Come to the Centaur; fetch our stuff from thence:</A><br>
 <A NAME=176>I long that we were safe and sound aboard.</A><br>
@@ -563,10 +536,9 @@
 <A NAME=180>the mountain of mad flesh that claims marriage of</A><br>
 <A NAME=181>me, I could find in my heart to stay here still and</A><br>
 <A NAME=182>turn witch.</A><br>
-<A NAME=183>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech87><b>OF SYRACUSE</b></a>
+<A NAME=speech87><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=184>I will not stay to-night for all the town;</A><br>
 <A NAME=185>Therefore away, to get our stuff aboard.</A><br>

--- a/comedy_errors/comedy_errors.5.1.html
+++ b/comedy_errors/comedy_errors.5.1.html
@@ -675,7 +675,7 @@
 <A NAME=307>Why look you strange on me? you know me well.</A><br>
 </blockquote>
 
-<A NAME=speech86><b>ANTIPHOLUS</b></a>
+<A NAME=speech86><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=308>I never saw you in my life till now.</A><br>
 </blockquote>

--- a/comedy_errors/comedy_errors.5.1.html
+++ b/comedy_errors/comedy_errors.5.1.html
@@ -67,10 +67,9 @@
 <A NAME=20>Who, but for staying on our controversy,</A><br>
 <A NAME=21>Had hoisted sail and put to sea to-day:</A><br>
 <A NAME=22>This chain you had of me; can you deny it?</A><br>
-<A NAME=23>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF SYRACUSE</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=24>I think I had; I never did deny it.</A><br>
 </blockquote>
@@ -78,10 +77,9 @@
 <A NAME=speech7><b>Second Merchant</b></a>
 <blockquote>
 <A NAME=25>Yes, that you did, sir, and forswore it too.</A><br>
-<A NAME=26>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF SYRACUSE</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=27>Who heard me to deny it or forswear it?</A><br>
 </blockquote>
@@ -91,10 +89,9 @@
 <A NAME=28>These ears of mine, thou know'st did hear thee.</A><br>
 <A NAME=29>Fie on thee, wretch! 'tis pity that thou livest</A><br>
 <A NAME=30>To walk where any honest man resort.</A><br>
-<A NAME=31>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF SYRACUSE</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=32>Thou art a villain to impeach me thus:</A><br>
 <A NAME=33>I'll prove mine honour and mine honesty</A><br>
@@ -452,10 +449,9 @@
 <A NAME=193>Even now we housed him in the abbey here;</A><br>
 <A NAME=194>And now he's there, past thought of human reason.</A><br>
 <p><i>Enter ANTIPHOLUS of Ephesus and DROMIO of Ephesus</i></p>
-<A NAME=195>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech57><b>OF EPHESUS</b></a>
+<A NAME=speech57><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=196>Justice, most gracious duke, O, grant me justice!</A><br>
 <A NAME=197>Even for the service that long since I did thee,</A><br>
@@ -468,10 +464,9 @@
 <blockquote>
 <A NAME=201>Unless the fear of death doth make me dote,</A><br>
 <A NAME=202>I see my son Antipholus and Dromio.</A><br>
-<A NAME=203>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech59><b>OF EPHESUS</b></a>
+<A NAME=speech59><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=204>Justice, sweet prince, against that woman there!</A><br>
 <A NAME=205>She whom thou gavest to me to be my wife,</A><br>
@@ -484,10 +479,9 @@
 <A NAME=speech60><b>DUKE SOLINUS</b></a>
 <blockquote>
 <A NAME=210>Discover how, and thou shalt find me just.</A><br>
-<A NAME=211>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech61><b>OF EPHESUS</b></a>
+<A NAME=speech61><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=212>This day, great duke, she shut the doors upon me,</A><br>
 <A NAME=213>While she with harlots feasted in my house.</A><br>
@@ -515,10 +509,9 @@
 <blockquote>
 <A NAME=220>O perjured woman! They are both forsworn:</A><br>
 <A NAME=221>In this the madman justly chargeth them.</A><br>
-<A NAME=222>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech66><b>OF EPHESUS</b></a>
+<A NAME=speech66><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=223>My liege, I am advised what I say,</A><br>
 <A NAME=224>Neither disturbed with the effect of wine,</A><br>
@@ -588,10 +581,9 @@
 <A NAME=272>And thereupon I drew my sword on you;</A><br>
 <A NAME=273>And then you fled into this abbey here,</A><br>
 <A NAME=274>From whence, I think, you are come by miracle.</A><br>
-<A NAME=275>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech71><b>OF EPHESUS</b></a>
+<A NAME=speech71><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=276>I never came within these abbey-walls,</A><br>
 <A NAME=277>Nor ever didst thou draw thy sword on me:</A><br>
@@ -617,10 +609,9 @@
 <A NAME=speech74><b>Courtezan</b></a>
 <blockquote>
 <A NAME=287>He did, and from my finger snatch'd that ring.</A><br>
-<A NAME=288>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech75><b>OF EPHESUS</b></a>
+<A NAME=speech75><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=289>'Tis true, my liege; this ring I had of her.</A><br>
 </blockquote>
@@ -695,10 +686,9 @@
 <A NAME=310>And careful hours with time's deformed hand</A><br>
 <A NAME=311>Have written strange defeatures in my face:</A><br>
 <A NAME=312>But tell me yet, dost thou not know my voice?</A><br>
-<A NAME=313>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech88><b>OF EPHESUS</b></a>
+<A NAME=speech88><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=314>Neither.</A><br>
 </blockquote>
@@ -738,10 +728,9 @@
 <A NAME=329>My dull deaf ears a little use to hear:</A><br>
 <A NAME=330>All these old witnesses--I cannot err--</A><br>
 <A NAME=331>Tell me thou art my son Antipholus.</A><br>
-<A NAME=332>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech94><b>OF EPHESUS</b></a>
+<A NAME=speech94><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=333>I never saw my father in my life.</A><br>
 </blockquote>
@@ -751,10 +740,9 @@
 <A NAME=334>But seven years since, in Syracusa, boy,</A><br>
 <A NAME=335>Thou know'st we parted: but perhaps, my son,</A><br>
 <A NAME=336>Thou shamest to acknowledge me in misery.</A><br>
-<A NAME=337>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech96><b>OF EPHESUS</b></a>
+<A NAME=speech96><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=338>The duke and all that know me in the city</A><br>
 <A NAME=339>Can witness with me that it is not so</A><br>
@@ -796,10 +784,9 @@
 <A NAME=speech102><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=351>I, sir, am Dromio; pray, let me stay.</A><br>
-<A NAME=352>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech103><b>OF SYRACUSE</b></a>
+<A NAME=speech103><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=353>AEgeon art thou not? or else his ghost?</A><br>
 </blockquote>
@@ -847,10 +834,9 @@
 <A NAME=376>These are the parents to these children,</A><br>
 <A NAME=377>Which accidentally are met together.</A><br>
 <A NAME=378>Antipholus, thou camest from Corinth first?</A><br>
-<A NAME=379>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech109><b>OF SYRACUSE</b></a>
+<A NAME=speech109><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=380>No, sir, not I; I came from Syracuse.</A><br>
 </blockquote>
@@ -858,10 +844,9 @@
 <A NAME=speech110><b>DUKE SOLINUS</b></a>
 <blockquote>
 <A NAME=381>Stay, stand apart; I know not which is which.</A><br>
-<A NAME=382>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech111><b>OF EPHESUS</b></a>
+<A NAME=speech111><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=383>I came from Corinth, my most gracious lord,--</A><br>
 </blockquote>
@@ -869,10 +854,9 @@
 <A NAME=speech112><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=384>And I with him.</A><br>
-<A NAME=385>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech113><b>OF EPHESUS</b></a>
+<A NAME=speech113><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=386>Brought to this town by that most famous warrior,</A><br>
 <A NAME=387>Duke Menaphon, your most renowned uncle.</A><br>
@@ -881,10 +865,9 @@
 <A NAME=speech114><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=388>Which of you two did dine with me to-day?</A><br>
-<A NAME=389>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech115><b>OF SYRACUSE</b></a>
+<A NAME=speech115><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=390>I, gentle mistress.</A><br>
 </blockquote>
@@ -892,16 +875,14 @@
 <A NAME=speech116><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=391>And are not you my husband?</A><br>
-<A NAME=392>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech117><b>OF EPHESUS</b></a>
+<A NAME=speech117><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=393>No; I say nay to that.</A><br>
-<A NAME=394>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech118><b>OF SYRACUSE</b></a>
+<A NAME=speech118><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=395>And so do I; yet did she call me so:</A><br>
 <A NAME=396>And this fair gentlewoman, her sister here,</A><br>
@@ -915,16 +896,14 @@
 <A NAME=speech119><b>ANGELO</b></a>
 <blockquote>
 <A NAME=401>That is the chain, sir, which you had of me.</A><br>
-<A NAME=402>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech120><b>OF SYRACUSE</b></a>
+<A NAME=speech120><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=403>I think it be, sir; I deny it not.</A><br>
-<A NAME=404>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech121><b>OF EPHESUS</b></a>
+<A NAME=speech121><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=405>And you, sir, for this chain arrested me.</A><br>
 </blockquote>
@@ -943,20 +922,18 @@
 <A NAME=speech124><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=409>No, none by me.</A><br>
-<A NAME=410>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech125><b>OF SYRACUSE</b></a>
+<A NAME=speech125><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=411>This purse of ducats I received from you,</A><br>
 <A NAME=412>And Dromio, my man, did bring them me.</A><br>
 <A NAME=413>I see we still did meet each other's man,</A><br>
 <A NAME=414>And I was ta'en for him, and he for me,</A><br>
 <A NAME=415>And thereupon these errors are arose.</A><br>
-<A NAME=416>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech126><b>OF EPHESUS</b></a>
+<A NAME=speech126><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=417>These ducats pawn I for my father here.</A><br>
 </blockquote>
@@ -969,10 +946,9 @@
 <A NAME=speech128><b>Courtezan</b></a>
 <blockquote>
 <A NAME=419>Sir, I must have that diamond from you.</A><br>
-<A NAME=420>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech129><b>OF EPHESUS</b></a>
+<A NAME=speech129><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=421>There, take it; and much thanks for my good cheer.</A><br>
 </blockquote>
@@ -1004,10 +980,9 @@
 <A NAME=speech132><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=437>Master, shall I fetch your stuff from shipboard?</A><br>
-<A NAME=438>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech133><b>OF EPHESUS</b></a>
+<A NAME=speech133><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=439>Dromio, what stuff of mine hast thou embark'd?</A><br>
 </blockquote>
@@ -1015,10 +990,9 @@
 <A NAME=speech134><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=440>Your goods that lay at host, sir, in the Centaur.</A><br>
-<A NAME=441>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech135><b>OF SYRACUSE</b></a>
+<A NAME=speech135><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=442>He speaks to me. I am your master, Dromio:</A><br>
 <A NAME=443>Come, go with us; we'll look to that anon:</A><br>

--- a/comedy_errors/full.html
+++ b/comedy_errors/full.html
@@ -1451,10 +1451,9 @@
 <A NAME=3.1.77>answered him well.</A><br>
 </blockquote>
 
-<A NAME=speech29><b>ANTIPHOLUS</b></a>
+<A NAME=speech29><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.78>Do you hear, you minion? you'll let us in, I hope?</A><br>
-<A NAME=3.1.79>OF EPHESUS</A><br>
 </blockquote>
 
 <A NAME=speech30><b>LUCE</b></a>
@@ -1826,7 +1825,7 @@
 <A NAME=3.2.87>I am an ass, I am a woman's man and besides myself.</A><br>
 </blockquote>
 
-<A NAME=speech20><b>ANTIPHOLUS</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.88>What woman's man? and how besides thyself? besides thyself?</A><br>
 </blockquote>
@@ -2905,7 +2904,7 @@
 <A NAME=4.4.30>your blows.</A><br>
 </blockquote>
 
-<A NAME=speech16><b>ANTIPHOLUS</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.31>Thou art sensible in nothing but blows, and so is an</A><br>
 <A NAME=4.4.32>ass.</A><br>
@@ -3991,7 +3990,7 @@
 <A NAME=5.1.307>Why look you strange on me? you know me well.</A><br>
 </blockquote>
 
-<A NAME=speech86><b>ANTIPHOLUS</b></a>
+<A NAME=speech86><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.308>I never saw you in my life till now.</A><br>
 </blockquote>

--- a/comedy_errors/full.html
+++ b/comedy_errors/full.html
@@ -245,10 +245,9 @@
 <A NAME=1.2.6>According to the statute of the town,</A><br>
 <A NAME=1.2.7>Dies ere the weary sun set in the west.</A><br>
 <A NAME=1.2.8>There is your money that I had to keep.</A><br>
-<A NAME=1.2.9>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech2><b>OF SYRACUSE</b></a>
+<A NAME=speech2><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.10>Go bear it to the Centaur, where we host,</A><br>
 <A NAME=1.2.11>And stay there, Dromio, till I come to thee.</A><br>
@@ -265,10 +264,9 @@
 <A NAME=1.2.18>Many a man would take you at your word,</A><br>
 <A NAME=1.2.19>And go indeed, having so good a mean.</A><br>
 <p><i>Exit</i></p>
-<A NAME=1.2.20>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech4><b>OF SYRACUSE</b></a>
+<A NAME=speech4><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.21>A trusty villain, sir, that very oft,</A><br>
 <A NAME=1.2.22>When I am dull with care and melancholy,</A><br>
@@ -285,10 +283,9 @@
 <A NAME=1.2.29>Please you, I'll meet with you upon the mart</A><br>
 <A NAME=1.2.30>And afterward consort you till bed-time:</A><br>
 <A NAME=1.2.31>My present business calls me from you now.</A><br>
-<A NAME=1.2.32>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF SYRACUSE</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.33>Farewell till then: I will go lose myself</A><br>
 <A NAME=1.2.34>And wander up and down to view the city.</A><br>
@@ -298,10 +295,9 @@
 <blockquote>
 <A NAME=1.2.35>Sir, I commend you to your own content.</A><br>
 <p><i>Exit</i></p>
-<A NAME=1.2.36>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF SYRACUSE</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.37>He that commends me to mine own content</A><br>
 <A NAME=1.2.38>Commends me to the thing I cannot get.</A><br>
@@ -328,10 +324,9 @@
 <A NAME=1.2.54>You have no stomach having broke your fast;</A><br>
 <A NAME=1.2.55>But we that know what 'tis to fast and pray</A><br>
 <A NAME=1.2.56>Are penitent for your default to-day.</A><br>
-<A NAME=1.2.57>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF SYRACUSE</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.58>Stop in your wind, sir: tell me this, I pray:</A><br>
 <A NAME=1.2.59>Where have you left the money that I gave you?</A><br>
@@ -342,10 +337,9 @@
 <A NAME=1.2.60>O,--sixpence, that I had o' Wednesday last</A><br>
 <A NAME=1.2.61>To pay the saddler for my mistress' crupper?</A><br>
 <A NAME=1.2.62>The saddler had it, sir; I kept it not.</A><br>
-<A NAME=1.2.63>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech12><b>OF SYRACUSE</b></a>
+<A NAME=speech12><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.64>I am not in a sportive humour now:</A><br>
 <A NAME=1.2.65>Tell me, and dally not, where is the money?</A><br>
@@ -361,10 +355,9 @@
 <A NAME=1.2.71>For she will score your fault upon my pate.</A><br>
 <A NAME=1.2.72>Methinks your maw, like mine, should be your clock,</A><br>
 <A NAME=1.2.73>And strike you home without a messenger.</A><br>
-<A NAME=1.2.74>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF SYRACUSE</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.75>Come, Dromio, come, these jests are out of season;</A><br>
 <A NAME=1.2.76>Reserve them till a merrier hour than this.</A><br>
@@ -374,10 +367,9 @@
 <A NAME=speech15><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=1.2.78>To me, sir? why, you gave no gold to me.</A><br>
-<A NAME=1.2.79>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech16><b>OF SYRACUSE</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.80>Come on, sir knave, have done your foolishness,</A><br>
 <A NAME=1.2.81>And tell me how thou hast disposed thy charge.</A><br>
@@ -388,10 +380,9 @@
 <A NAME=1.2.82>My charge was but to fetch you from the mart</A><br>
 <A NAME=1.2.83>Home to your house, the Phoenix, sir, to dinner:</A><br>
 <A NAME=1.2.84>My mistress and her sister stays for you.</A><br>
-<A NAME=1.2.85>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF SYRACUSE</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.86>In what safe place you have bestow'd my money,</A><br>
 <A NAME=1.2.87>Or I shall break that merry sconce of yours</A><br>
@@ -406,10 +397,9 @@
 <A NAME=1.2.92>But not a thousand marks between you both.</A><br>
 <A NAME=1.2.93>If I should pay your worship those again,</A><br>
 <A NAME=1.2.94>Perchance you will not bear them patiently.</A><br>
-<A NAME=1.2.95>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech20><b>OF SYRACUSE</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.96>Thy mistress' marks? what mistress, slave, hast thou?</A><br>
 </blockquote>
@@ -419,10 +409,9 @@
 <A NAME=1.2.97>Your worship's wife, my mistress at the Phoenix;</A><br>
 <A NAME=1.2.98>She that doth fast till you come home to dinner,</A><br>
 <A NAME=1.2.99>And prays that you will hie you home to dinner.</A><br>
-<A NAME=1.2.100>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech22><b>OF SYRACUSE</b></a>
+<A NAME=speech22><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.101>What, wilt thou flout me thus unto my face,</A><br>
 <A NAME=1.2.102>Being forbid? There, take you that, sir knave.</A><br>
@@ -433,10 +422,9 @@
 <A NAME=1.2.103>What mean you, sir? for God's sake, hold your hands!</A><br>
 <A NAME=1.2.104>Nay, and you will not, sir, I'll take my heels.</A><br>
 <p><i>Exit</i></p>
-<A NAME=1.2.105>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech24><b>OF SYRACUSE</b></a>
+<A NAME=speech24><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=1.2.106>Upon my life, by some device or other</A><br>
 <A NAME=1.2.107>The villain is o'er-raught of all my money.</A><br>
@@ -735,11 +723,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Syracuse</i>
 </blockquote>
-<blockquote>
-<A NAME=2.2.1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF SYRACUSE</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.2>The gold I gave to Dromio is laid up</A><br>
 <A NAME=2.2.3>Safe at the Centaur; and the heedful slave</A><br>
@@ -759,10 +744,9 @@
 <A NAME=speech2><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.14>What answer, sir? when spake I such a word?</A><br>
-<A NAME=2.2.15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF SYRACUSE</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.16>Even now, even here, not half an hour since.</A><br>
 </blockquote>
@@ -771,10 +755,9 @@
 <blockquote>
 <A NAME=2.2.17>I did not see you since you sent me hence,</A><br>
 <A NAME=2.2.18>Home to the Centaur, with the gold you gave me.</A><br>
-<A NAME=2.2.19>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF SYRACUSE</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.20>Villain, thou didst deny the gold's receipt,</A><br>
 <A NAME=2.2.21>And told'st me of a mistress and a dinner;</A><br>
@@ -785,10 +768,9 @@
 <blockquote>
 <A NAME=2.2.23>I am glad to see you in this merry vein:</A><br>
 <A NAME=2.2.24>What means this jest? I pray you, master, tell me.</A><br>
-<A NAME=2.2.25>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF SYRACUSE</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.26>Yea, dost thou jeer and flout me in the teeth?</A><br>
 <A NAME=2.2.27>Think'st thou I jest? Hold, take thou that, and that.</A><br>
@@ -799,10 +781,9 @@
 <blockquote>
 <A NAME=2.2.28>Hold, sir, for God's sake! now your jest is earnest:</A><br>
 <A NAME=2.2.29>Upon what bargain do you give it me?</A><br>
-<A NAME=2.2.30>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF SYRACUSE</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.31>Because that I familiarly sometimes</A><br>
 <A NAME=2.2.32>Do use you for my fool and chat with you,</A><br>
@@ -822,10 +803,9 @@
 <A NAME=2.2.42>long, I must get a sconce for my head and ensconce</A><br>
 <A NAME=2.2.43>it too; or else I shall seek my wit in my shoulders.</A><br>
 <A NAME=2.2.44>But, I pray, sir why am I beaten?</A><br>
-<A NAME=2.2.45>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech11><b>OF SYRACUSE</b></a>
+<A NAME=speech11><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.46>Dost thou not know?</A><br>
 </blockquote>
@@ -833,10 +813,9 @@
 <A NAME=speech12><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.47>Nothing, sir, but that I am beaten.</A><br>
-<A NAME=2.2.48>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech13><b>OF SYRACUSE</b></a>
+<A NAME=speech13><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.49>Shall I tell you why?</A><br>
 </blockquote>
@@ -845,10 +824,9 @@
 <blockquote>
 <A NAME=2.2.50>Ay, sir, and wherefore; for they say every why hath</A><br>
 <A NAME=2.2.51>a wherefore.</A><br>
-<A NAME=2.2.52>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech15><b>OF SYRACUSE</b></a>
+<A NAME=speech15><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.53>Why, first,--for flouting me; and then, wherefore--</A><br>
 <A NAME=2.2.54>For urging it the second time to me.</A><br>
@@ -860,10 +838,9 @@
 <A NAME=2.2.56>When in the why and the wherefore is neither rhyme</A><br>
 <A NAME=2.2.57>nor reason?</A><br>
 <A NAME=2.2.58>Well, sir, I thank you.</A><br>
-<A NAME=2.2.59>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech17><b>OF SYRACUSE</b></a>
+<A NAME=speech17><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.60>Thank me, sir, for what?</A><br>
 </blockquote>
@@ -871,10 +848,9 @@
 <A NAME=speech18><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.61>Marry, sir, for this something that you gave me for nothing.</A><br>
-<A NAME=2.2.62>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech19><b>OF SYRACUSE</b></a>
+<A NAME=speech19><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.63>I'll make you amends next, to give you nothing for</A><br>
 <A NAME=2.2.64>something. But say, sir, is it dinner-time?</A><br>
@@ -883,10 +859,9 @@
 <A NAME=speech20><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.65>No, sir; I think the meat wants that I have.</A><br>
-<A NAME=2.2.66>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech21><b>OF SYRACUSE</b></a>
+<A NAME=speech21><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.67>In good time, sir; what's that?</A><br>
 </blockquote>
@@ -894,10 +869,9 @@
 <A NAME=speech22><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.68>Basting.</A><br>
-<A NAME=2.2.69>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech23><b>OF SYRACUSE</b></a>
+<A NAME=speech23><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.70>Well, sir, then 'twill be dry.</A><br>
 </blockquote>
@@ -905,10 +879,9 @@
 <A NAME=speech24><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.71>If it be, sir, I pray you, eat none of it.</A><br>
-<A NAME=2.2.72>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech25><b>OF SYRACUSE</b></a>
+<A NAME=speech25><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.73>Your reason?</A><br>
 </blockquote>
@@ -917,10 +890,9 @@
 <blockquote>
 <A NAME=2.2.74>Lest it make you choleric and purchase me another</A><br>
 <A NAME=2.2.75>dry basting.</A><br>
-<A NAME=2.2.76>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech27><b>OF SYRACUSE</b></a>
+<A NAME=speech27><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.77>Well, sir, learn to jest in good time: there's a</A><br>
 <A NAME=2.2.78>time for all things.</A><br>
@@ -929,10 +901,9 @@
 <A NAME=speech28><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.79>I durst have denied that, before you were so choleric.</A><br>
-<A NAME=2.2.80>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech29><b>OF SYRACUSE</b></a>
+<A NAME=speech29><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.81>By what rule, sir?</A><br>
 </blockquote>
@@ -941,10 +912,9 @@
 <blockquote>
 <A NAME=2.2.82>Marry, sir, by a rule as plain as the plain bald</A><br>
 <A NAME=2.2.83>pate of father Time himself.</A><br>
-<A NAME=2.2.84>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech31><b>OF SYRACUSE</b></a>
+<A NAME=speech31><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.85>Let's hear it.</A><br>
 </blockquote>
@@ -953,10 +923,9 @@
 <blockquote>
 <A NAME=2.2.86>There's no time for a man to recover his hair that</A><br>
 <A NAME=2.2.87>grows bald by nature.</A><br>
-<A NAME=2.2.88>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech33><b>OF SYRACUSE</b></a>
+<A NAME=speech33><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.89>May he not do it by fine and recovery?</A><br>
 </blockquote>
@@ -965,10 +934,9 @@
 <blockquote>
 <A NAME=2.2.90>Yes, to pay a fine for a periwig and recover the</A><br>
 <A NAME=2.2.91>lost hair of another man.</A><br>
-<A NAME=2.2.92>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech35><b>OF SYRACUSE</b></a>
+<A NAME=speech35><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.93>Why is Time such a niggard of hair, being, as it is,</A><br>
 <A NAME=2.2.94>so plentiful an excrement?</A><br>
@@ -978,10 +946,9 @@
 <blockquote>
 <A NAME=2.2.95>Because it is a blessing that he bestows on beasts;</A><br>
 <A NAME=2.2.96>and what he hath scanted men in hair he hath given them in wit.</A><br>
-<A NAME=2.2.97>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech37><b>OF SYRACUSE</b></a>
+<A NAME=speech37><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.98>Why, but there's many a man hath more hair than wit.</A><br>
 </blockquote>
@@ -989,10 +956,9 @@
 <A NAME=speech38><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.99>Not a man of those but he hath the wit to lose his hair.</A><br>
-<A NAME=2.2.100>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech39><b>OF SYRACUSE</b></a>
+<A NAME=speech39><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.101>Why, thou didst conclude hairy men plain dealers without wit.</A><br>
 </blockquote>
@@ -1001,10 +967,9 @@
 <blockquote>
 <A NAME=2.2.102>The plainer dealer, the sooner lost: yet he loseth</A><br>
 <A NAME=2.2.103>it in a kind of jollity.</A><br>
-<A NAME=2.2.104>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech41><b>OF SYRACUSE</b></a>
+<A NAME=speech41><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.105>For what reason?</A><br>
 </blockquote>
@@ -1012,10 +977,9 @@
 <A NAME=speech42><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.106>For two; and sound ones too.</A><br>
-<A NAME=2.2.107>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech43><b>OF SYRACUSE</b></a>
+<A NAME=speech43><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.108>Nay, not sound, I pray you.</A><br>
 </blockquote>
@@ -1023,10 +987,9 @@
 <A NAME=speech44><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.109>Sure ones, then.</A><br>
-<A NAME=2.2.110>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech45><b>OF SYRACUSE</b></a>
+<A NAME=speech45><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.111>Nay, not sure, in a thing falsing.</A><br>
 </blockquote>
@@ -1034,10 +997,9 @@
 <A NAME=speech46><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.112>Certain ones then.</A><br>
-<A NAME=2.2.113>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech47><b>OF SYRACUSE</b></a>
+<A NAME=speech47><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.114>Name them.</A><br>
 </blockquote>
@@ -1047,10 +1009,9 @@
 <A NAME=2.2.115>The one, to save the money that he spends in</A><br>
 <A NAME=2.2.116>trimming; the other, that at dinner they should not</A><br>
 <A NAME=2.2.117>drop in his porridge.</A><br>
-<A NAME=2.2.118>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech49><b>OF SYRACUSE</b></a>
+<A NAME=speech49><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.119>You would all this time have proved there is no</A><br>
 <A NAME=2.2.120>time for all things.</A><br>
@@ -1060,10 +1021,9 @@
 <blockquote>
 <A NAME=2.2.121>Marry, and did, sir; namely, no time to recover hair</A><br>
 <A NAME=2.2.122>lost by nature.</A><br>
-<A NAME=2.2.123>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech51><b>OF SYRACUSE</b></a>
+<A NAME=speech51><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.124>But your reason was not substantial, why there is no</A><br>
 <A NAME=2.2.125>time to recover.</A><br>
@@ -1073,10 +1033,9 @@
 <blockquote>
 <A NAME=2.2.126>Thus I mend it: Time himself is bald and therefore</A><br>
 <A NAME=2.2.127>to the world's end will have bald followers.</A><br>
-<A NAME=2.2.128>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech53><b>OF SYRACUSE</b></a>
+<A NAME=speech53><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.129>I knew 'twould be a bald conclusion:</A><br>
 <A NAME=2.2.130>But, soft! who wafts us yonder?</A><br>
@@ -1122,10 +1081,9 @@
 <A NAME=2.2.165>Being strumpeted by thy contagion.</A><br>
 <A NAME=2.2.166>Keep then far league and truce with thy true bed;</A><br>
 <A NAME=2.2.167>I live unstain'd, thou undishonoured.</A><br>
-<A NAME=2.2.168>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech55><b>OF SYRACUSE</b></a>
+<A NAME=speech55><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.169>Plead you to me, fair dame? I know you not:</A><br>
 <A NAME=2.2.170>In Ephesus I am but two hours old,</A><br>
@@ -1139,10 +1097,9 @@
 <A NAME=2.2.174>Fie, brother! how the world is changed with you!</A><br>
 <A NAME=2.2.175>When were you wont to use my sister thus?</A><br>
 <A NAME=2.2.176>She sent for you by Dromio home to dinner.</A><br>
-<A NAME=2.2.177>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech57><b>OF SYRACUSE</b></a>
+<A NAME=speech57><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.178>By Dromio?</A><br>
 </blockquote>
@@ -1157,10 +1114,9 @@
 <A NAME=2.2.180>By thee; and this thou didst return from him,</A><br>
 <A NAME=2.2.181>That he did buffet thee, and, in his blows,</A><br>
 <A NAME=2.2.182>Denied my house for his, me for his wife.</A><br>
-<A NAME=2.2.183>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech60><b>OF SYRACUSE</b></a>
+<A NAME=speech60><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.184>Did you converse, sir, with this gentlewoman?</A><br>
 <A NAME=2.2.185>What is the course and drift of your compact?</A><br>
@@ -1169,10 +1125,9 @@
 <A NAME=speech61><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.186>I, sir? I never saw her till this time.</A><br>
-<A NAME=2.2.187>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech62><b>OF SYRACUSE</b></a>
+<A NAME=speech62><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.188>Villain, thou liest; for even her very words</A><br>
 <A NAME=2.2.189>Didst thou deliver to me on the mart.</A><br>
@@ -1181,10 +1136,9 @@
 <A NAME=speech63><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.190>I never spake with her in all my life.</A><br>
-<A NAME=2.2.191>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech64><b>OF SYRACUSE</b></a>
+<A NAME=speech64><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.192>How can she thus then call us by our names,</A><br>
 <A NAME=2.2.193>Unless it be by inspiration.</A><br>
@@ -1205,10 +1159,9 @@
 <A NAME=2.2.204>Usurping ivy, brier, or idle moss;</A><br>
 <A NAME=2.2.205>Who, all for want of pruning, with intrusion</A><br>
 <A NAME=2.2.206>Infect thy sap and live on thy confusion.</A><br>
-<A NAME=2.2.207>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech66><b>OF SYRACUSE</b></a>
+<A NAME=speech66><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.208>To me she speaks; she moves me for her theme:</A><br>
 <A NAME=2.2.209>What, was I married to her in my dream?</A><br>
@@ -1241,10 +1194,9 @@
 <A NAME=speech70><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.222>I am transformed, master, am I not?</A><br>
-<A NAME=2.2.223>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech71><b>OF SYRACUSE</b></a>
+<A NAME=speech71><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.224>I think thou art in mind, and so am I.</A><br>
 </blockquote>
@@ -1252,10 +1204,9 @@
 <A NAME=speech72><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.225>Nay, master, both in mind and in my shape.</A><br>
-<A NAME=2.2.226>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech73><b>OF SYRACUSE</b></a>
+<A NAME=speech73><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.227>Thou hast thine own form.</A><br>
 </blockquote>
@@ -1288,10 +1239,9 @@
 <A NAME=2.2.239>Sirrah, if any ask you for your master,</A><br>
 <A NAME=2.2.240>Say he dines forth, and let no creature enter.</A><br>
 <A NAME=2.2.241>Come, sister. Dromio, play the porter well.</A><br>
-<A NAME=2.2.242>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech78><b>OF SYRACUSE</b></a>
+<A NAME=speech78><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=2.2.243>Am I in earth, in heaven, or in hell?</A><br>
 <A NAME=2.2.244>Sleeping or waking? mad or well-advised?</A><br>
@@ -1320,11 +1270,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Ephesus, DROMIO of Ephesus, ANGELO, and BALTHAZAR</i>
 </blockquote>
-<blockquote>
-<A NAME=3.1.1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF EPHESUS</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.2>Good Signior Angelo, you must excuse us all;</A><br>
 <A NAME=3.1.3>My wife is shrewish when I keep not hours:</A><br>
@@ -1344,10 +1291,9 @@
 <A NAME=3.1.13>That you beat me at the mart, I have your hand to show:</A><br>
 <A NAME=3.1.14>If the skin were parchment, and the blows you gave were ink,</A><br>
 <A NAME=3.1.15>Your own handwriting would tell you what I think.</A><br>
-<A NAME=3.1.16>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF EPHESUS</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.17>I think thou art an ass.</A><br>
 </blockquote>
@@ -1358,10 +1304,9 @@
 <A NAME=3.1.19>By the wrongs I suffer and the blows I bear.</A><br>
 <A NAME=3.1.20>I should kick, being kick'd; and, being at that pass,</A><br>
 <A NAME=3.1.21>You would keep from my heels and beware of an ass.</A><br>
-<A NAME=3.1.22>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF EPHESUS</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.23>You're sad, Signior Balthazar: pray God our cheer</A><br>
 <A NAME=3.1.24>May answer my good will and your good welcome here.</A><br>
@@ -1371,10 +1316,9 @@
 <blockquote>
 <A NAME=3.1.25>I hold your dainties cheap, sir, and your</A><br>
 <A NAME=3.1.26>welcome dear.</A><br>
-<A NAME=3.1.27>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF EPHESUS</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.28>O, Signior Balthazar, either at flesh or fish,</A><br>
 <A NAME=3.1.29>A table full of welcome make scarce one dainty dish.</A><br>
@@ -1383,10 +1327,9 @@
 <A NAME=speech8><b>BALTHAZAR</b></a>
 <blockquote>
 <A NAME=3.1.30>Good meat, sir, is common; that every churl affords.</A><br>
-<A NAME=3.1.31>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF EPHESUS</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.32>And welcome more common; for that's nothing but words.</A><br>
 </blockquote>
@@ -1394,10 +1337,9 @@
 <A NAME=speech10><b>BALTHAZAR</b></a>
 <blockquote>
 <A NAME=3.1.33>Small cheer and great welcome makes a merry feast.</A><br>
-<A NAME=3.1.34>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech11><b>OF EPHESUS</b></a>
+<A NAME=speech11><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.35>Ay, to a niggardly host, and more sparing guest:</A><br>
 <A NAME=3.1.36>But though my cates be mean, take them in good part;</A><br>
@@ -1430,10 +1372,9 @@
 <blockquote>
 <A NAME=3.1.48>[Within]  Let him walk from whence he came, lest he</A><br>
 <A NAME=3.1.49>catch cold on's feet.</A><br>
-<A NAME=3.1.50>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech16><b>OF EPHESUS</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.51>Who talks within there? ho, open the door!</A><br>
 </blockquote>
@@ -1442,10 +1383,9 @@
 <blockquote>
 <A NAME=3.1.52>[Within]  Right, sir; I'll tell you when, an you tell</A><br>
 <A NAME=3.1.53>me wherefore.</A><br>
-<A NAME=3.1.54>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF EPHESUS</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.55>Wherefore? for my dinner: I have not dined to-day.</A><br>
 </blockquote>
@@ -1454,10 +1394,9 @@
 <blockquote>
 <A NAME=3.1.56>[Within]  Nor to-day here you must not; come again</A><br>
 <A NAME=3.1.57>when you may.</A><br>
-<A NAME=3.1.58>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech20><b>OF EPHESUS</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.59>What art thou that keepest me out from the house I owe?</A><br>
 </blockquote>
@@ -1531,10 +1470,9 @@
 <A NAME=speech32><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.82>So, come, help: well struck! there was blow for blow.</A><br>
-<A NAME=3.1.83>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech33><b>OF EPHESUS</b></a>
+<A NAME=speech33><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.84>Thou baggage, let me in.</A><br>
 </blockquote>
@@ -1552,10 +1490,9 @@
 <A NAME=speech36><b>LUCE</b></a>
 <blockquote>
 <A NAME=3.1.87>[Within]  Let him knock till it ache.</A><br>
-<A NAME=3.1.88>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech37><b>OF EPHESUS</b></a>
+<A NAME=speech37><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.89>You'll cry for this, minion, if I beat the door down.</A><br>
 </blockquote>
@@ -1575,10 +1512,9 @@
 <blockquote>
 <A NAME=3.1.93>[Within]  By my troth, your town is troubled with</A><br>
 <A NAME=3.1.94>unruly boys.</A><br>
-<A NAME=3.1.95>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech41><b>OF EPHESUS</b></a>
+<A NAME=speech41><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.96>Are you there, wife? you might have come before.</A><br>
 </blockquote>
@@ -1607,10 +1543,9 @@
 <A NAME=speech46><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.102>They stand at the door, master; bid them welcome hither.</A><br>
-<A NAME=3.1.103>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech47><b>OF EPHESUS</b></a>
+<A NAME=speech47><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.104>There is something in the wind, that we cannot get in.</A><br>
 </blockquote>
@@ -1620,10 +1555,9 @@
 <A NAME=3.1.105>You would say so, master, if your garments were thin.</A><br>
 <A NAME=3.1.106>Your cake there is warm within; you stand here in the cold:</A><br>
 <A NAME=3.1.107>It would make a man mad as a buck, to be so bought and sold.</A><br>
-<A NAME=3.1.108>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech49><b>OF EPHESUS</b></a>
+<A NAME=speech49><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.109>Go fetch me something: I'll break ope the gate.</A><br>
 </blockquote>
@@ -1655,10 +1589,9 @@
 <A NAME=speech54><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.1.118>[Within]  Ay, when fowls have no feathers and fish have no fin.</A><br>
-<A NAME=3.1.119>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech55><b>OF EPHESUS</b></a>
+<A NAME=speech55><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.120>Well, I'll break in: go borrow me a crow.</A><br>
 </blockquote>
@@ -1668,10 +1601,9 @@
 <A NAME=3.1.121>A crow without feather? Master, mean you so?</A><br>
 <A NAME=3.1.122>For a fish without a fin, there's a fowl without a feather;</A><br>
 <A NAME=3.1.123>If a crow help us in, sirrah, we'll pluck a crow together.</A><br>
-<A NAME=3.1.124>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech57><b>OF EPHESUS</b></a>
+<A NAME=speech57><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.125>Go get thee gone; fetch me an iron crow.</A><br>
 </blockquote>
@@ -1700,10 +1632,9 @@
 <A NAME=3.1.145>And dwell upon your grave when you are dead;</A><br>
 <A NAME=3.1.146>For slander lives upon succession,</A><br>
 <A NAME=3.1.147>For ever housed where it gets possession.</A><br>
-<A NAME=3.1.148>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech59><b>OF EPHESUS</b></a>
+<A NAME=speech59><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.149>You have prevailed: I will depart in quiet,</A><br>
 <A NAME=3.1.150>And, in despite of mirth, mean to be merry.</A><br>
@@ -1727,10 +1658,9 @@
 <A NAME=speech60><b>ANGELO</b></a>
 <blockquote>
 <A NAME=3.1.165>I'll meet you at that place some hour hence.</A><br>
-<A NAME=3.1.166>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech61><b>OF EPHESUS</b></a>
+<A NAME=speech61><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=3.1.167>Do so. This jest shall cost me some expense.</A><br>
 <p><i>Exeunt</i></p>
@@ -1770,10 +1700,9 @@
 <A NAME=3.2.26>Comfort my sister, cheer her, call her wife:</A><br>
 <A NAME=3.2.27>'Tis holy sport to be a little vain,</A><br>
 <A NAME=3.2.28>When the sweet breath of flattery conquers strife.</A><br>
-<A NAME=3.2.29>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech2><b>OF SYRACUSE</b></a>
+<A NAME=speech2><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.30>Sweet mistress--what your name is else, I know not,</A><br>
 <A NAME=3.2.31>Nor by what wonder you do hit of mine,--</A><br>
@@ -1804,10 +1733,9 @@
 <A NAME=speech3><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=3.2.54>What, are you mad, that you do reason so?</A><br>
-<A NAME=3.2.55>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech4><b>OF SYRACUSE</b></a>
+<A NAME=speech4><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.56>Not mad, but mated; how, I do not know.</A><br>
 </blockquote>
@@ -1815,10 +1743,9 @@
 <A NAME=speech5><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=3.2.57>It is a fault that springeth from your eye.</A><br>
-<A NAME=3.2.58>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF SYRACUSE</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.59>For gazing on your beams, fair sun, being by.</A><br>
 </blockquote>
@@ -1826,10 +1753,9 @@
 <A NAME=speech7><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=3.2.60>Gaze where you should, and that will clear your sight.</A><br>
-<A NAME=3.2.61>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF SYRACUSE</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.62>As good to wink, sweet love, as look on night.</A><br>
 </blockquote>
@@ -1837,10 +1763,9 @@
 <A NAME=speech9><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=3.2.63>Why call you me love? call my sister so.</A><br>
-<A NAME=3.2.64>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF SYRACUSE</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.65>Thy sister's sister.</A><br>
 </blockquote>
@@ -1848,10 +1773,9 @@
 <A NAME=speech11><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=3.2.66>That's my sister.</A><br>
-<A NAME=3.2.67>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech12><b>OF SYRACUSE</b></a>
+<A NAME=speech12><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.68>No;</A><br>
 <A NAME=3.2.69>It is thyself, mine own self's better part,</A><br>
@@ -1863,10 +1787,9 @@
 <A NAME=speech13><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=3.2.73>All this my sister is, or else should be.</A><br>
-<A NAME=3.2.74>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF SYRACUSE</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.75>Call thyself sister, sweet, for I am thee.</A><br>
 <A NAME=3.2.76>Thee will I love and with thee lead my life:</A><br>
@@ -1880,10 +1803,9 @@
 <A NAME=3.2.80>I'll fetch my sister, to get her good will.</A><br>
 <p><i>Exit</i></p>
 <p><i>Enter DROMIO of Syracuse</i></p>
-<A NAME=3.2.81>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech16><b>OF SYRACUSE</b></a>
+<A NAME=speech16><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.82>Why, how now, Dromio! where runn'st thou so fast?</A><br>
 </blockquote>
@@ -1892,10 +1814,9 @@
 <blockquote>
 <A NAME=3.2.83>Do you know me, sir? am I Dromio? am I your man?</A><br>
 <A NAME=3.2.84>am I myself?</A><br>
-<A NAME=3.2.85>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF SYRACUSE</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.86>Thou art Dromio, thou art my man, thou art thyself.</A><br>
 </blockquote>
@@ -1914,10 +1835,9 @@
 <blockquote>
 <A NAME=3.2.89>Marry, sir, besides myself, I am due to a woman; one</A><br>
 <A NAME=3.2.90>that claims me, one that haunts me, one that will have me.</A><br>
-<A NAME=3.2.91>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech22><b>OF SYRACUSE</b></a>
+<A NAME=speech22><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.92>What claim lays she to thee?</A><br>
 </blockquote>
@@ -1928,10 +1848,9 @@
 <A NAME=3.2.94>horse; and she would have me as a beast: not that, I</A><br>
 <A NAME=3.2.95>being a beast, she would have me; but that she,</A><br>
 <A NAME=3.2.96>being a very beastly creature, lays claim to me.</A><br>
-<A NAME=3.2.97>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech24><b>OF SYRACUSE</b></a>
+<A NAME=speech24><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.98>What is she?</A><br>
 </blockquote>
@@ -1942,10 +1861,9 @@
 <A NAME=3.2.100>not speak of without he say 'Sir-reverence.' I have</A><br>
 <A NAME=3.2.101>but lean luck in the match, and yet is she a</A><br>
 <A NAME=3.2.102>wondrous fat marriage.</A><br>
-<A NAME=3.2.103>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech26><b>OF SYRACUSE</b></a>
+<A NAME=speech26><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.104>How dost thou mean a fat marriage?</A><br>
 </blockquote>
@@ -1958,10 +1876,9 @@
 <A NAME=3.2.108>warrant, her rags and the tallow in them will burn a</A><br>
 <A NAME=3.2.109>Poland winter: if she lives till doomsday,</A><br>
 <A NAME=3.2.110>she'll burn a week longer than the whole world.</A><br>
-<A NAME=3.2.111>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech28><b>OF SYRACUSE</b></a>
+<A NAME=speech28><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.112>What complexion is she of?</A><br>
 </blockquote>
@@ -1971,10 +1888,9 @@
 <A NAME=3.2.113>Swart, like my shoe, but her face nothing half so</A><br>
 <A NAME=3.2.114>clean kept: for why, she sweats; a man may go over</A><br>
 <A NAME=3.2.115>shoes in the grime of it.</A><br>
-<A NAME=3.2.116>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech30><b>OF SYRACUSE</b></a>
+<A NAME=speech30><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.117>That's a fault that water will mend.</A><br>
 </blockquote>
@@ -1982,10 +1898,9 @@
 <A NAME=speech31><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.118>No, sir, 'tis in grain; Noah's flood could not do it.</A><br>
-<A NAME=3.2.119>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech32><b>OF SYRACUSE</b></a>
+<A NAME=speech32><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.120>What's her name?</A><br>
 </blockquote>
@@ -1995,10 +1910,9 @@
 <A NAME=3.2.121>Nell, sir; but her name and three quarters, that's</A><br>
 <A NAME=3.2.122>an ell and three quarters, will not measure her from</A><br>
 <A NAME=3.2.123>hip to hip.</A><br>
-<A NAME=3.2.124>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech34><b>OF SYRACUSE</b></a>
+<A NAME=speech34><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.125>Then she bears some breadth?</A><br>
 </blockquote>
@@ -2008,10 +1922,9 @@
 <A NAME=3.2.126>No longer from head to foot than from hip to hip:</A><br>
 <A NAME=3.2.127>she is spherical, like a globe; I could find out</A><br>
 <A NAME=3.2.128>countries in her.</A><br>
-<A NAME=3.2.129>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech36><b>OF SYRACUSE</b></a>
+<A NAME=speech36><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.130>In what part of her body stands Ireland?</A><br>
 </blockquote>
@@ -2019,10 +1932,9 @@
 <A NAME=speech37><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.131>Marry, in her buttocks: I found it out by the bogs.</A><br>
-<A NAME=3.2.132>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech38><b>OF SYRACUSE</b></a>
+<A NAME=speech38><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.133>Where Scotland?</A><br>
 </blockquote>
@@ -2030,10 +1942,9 @@
 <A NAME=speech39><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.134>I found it by the barrenness; hard in the palm of the hand.</A><br>
-<A NAME=3.2.135>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech40><b>OF SYRACUSE</b></a>
+<A NAME=speech40><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.136>Where France?</A><br>
 </blockquote>
@@ -2042,10 +1953,9 @@
 <blockquote>
 <A NAME=3.2.137>In her forehead; armed and reverted, making war</A><br>
 <A NAME=3.2.138>against her heir.</A><br>
-<A NAME=3.2.139>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech42><b>OF SYRACUSE</b></a>
+<A NAME=speech42><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.140>Where England?</A><br>
 </blockquote>
@@ -2055,10 +1965,9 @@
 <A NAME=3.2.141>I looked for the chalky cliffs, but I could find no</A><br>
 <A NAME=3.2.142>whiteness in them; but I guess it stood in her chin,</A><br>
 <A NAME=3.2.143>by the salt rheum that ran between France and it.</A><br>
-<A NAME=3.2.144>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech44><b>OF SYRACUSE</b></a>
+<A NAME=speech44><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.145>Where Spain?</A><br>
 </blockquote>
@@ -2066,10 +1975,9 @@
 <A NAME=speech45><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.146>Faith, I saw it not; but I felt it hot in her breath.</A><br>
-<A NAME=3.2.147>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech46><b>OF SYRACUSE</b></a>
+<A NAME=speech46><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.148>Where America, the Indies?</A><br>
 </blockquote>
@@ -2080,10 +1988,9 @@
 <A NAME=3.2.150>rubies, carbuncles, sapphires, declining their rich</A><br>
 <A NAME=3.2.151>aspect to the hot breath of Spain; who sent whole</A><br>
 <A NAME=3.2.152>armadoes of caracks to be ballast at her nose.</A><br>
-<A NAME=3.2.153>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech48><b>OF SYRACUSE</b></a>
+<A NAME=speech48><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.154>Where stood Belgia, the Netherlands?</A><br>
 </blockquote>
@@ -2100,10 +2007,9 @@
 <A NAME=3.2.162>faith and my heart of steel,</A><br>
 <A NAME=3.2.163>She had transform'd me to a curtal dog and made</A><br>
 <A NAME=3.2.164>me turn i' the wheel.</A><br>
-<A NAME=3.2.165>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech50><b>OF SYRACUSE</b></a>
+<A NAME=speech50><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.166>Go hie thee presently, post to the road:</A><br>
 <A NAME=3.2.167>An if the wind blow any way from shore,</A><br>
@@ -2119,10 +2025,9 @@
 <A NAME=3.2.173>As from a bear a man would run for life,</A><br>
 <A NAME=3.2.174>So fly I from her that would be my wife.</A><br>
 <p><i>Exit</i></p>
-<A NAME=3.2.175>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech52><b>OF SYRACUSE</b></a>
+<A NAME=speech52><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.176>There's none but witches do inhabit here;</A><br>
 <A NAME=3.2.177>And therefore 'tis high time that I were hence.</A><br>
@@ -2139,10 +2044,9 @@
 <A NAME=speech53><b>ANGELO</b></a>
 <blockquote>
 <A NAME=3.2.185>Master Antipholus,--</A><br>
-<A NAME=3.2.186>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech54><b>OF SYRACUSE</b></a>
+<A NAME=speech54><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.187>Ay, that's my name.</A><br>
 </blockquote>
@@ -2152,10 +2056,9 @@
 <A NAME=3.2.188>I know it well, sir, lo, here is the chain.</A><br>
 <A NAME=3.2.189>I thought to have ta'en you at the Porpentine:</A><br>
 <A NAME=3.2.190>The chain unfinish'd made me stay thus long.</A><br>
-<A NAME=3.2.191>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech56><b>OF SYRACUSE</b></a>
+<A NAME=speech56><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.192>What is your will that I shall do with this?</A><br>
 </blockquote>
@@ -2163,10 +2066,9 @@
 <A NAME=speech57><b>ANGELO</b></a>
 <blockquote>
 <A NAME=3.2.193>What please yourself, sir: I have made it for you.</A><br>
-<A NAME=3.2.194>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech58><b>OF SYRACUSE</b></a>
+<A NAME=speech58><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.195>Made it for me, sir! I bespoke it not.</A><br>
 </blockquote>
@@ -2177,10 +2079,9 @@
 <A NAME=3.2.197>Go home with it and please your wife withal;</A><br>
 <A NAME=3.2.198>And soon at supper-time I'll visit you</A><br>
 <A NAME=3.2.199>And then receive my money for the chain.</A><br>
-<A NAME=3.2.200>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech60><b>OF SYRACUSE</b></a>
+<A NAME=speech60><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.201>I pray you, sir, receive the money now,</A><br>
 <A NAME=3.2.202>For fear you ne'er see chain nor money more.</A><br>
@@ -2190,10 +2091,9 @@
 <blockquote>
 <A NAME=3.2.203>You are a merry man, sir: fare you well.</A><br>
 <p><i>Exit</i></p>
-<A NAME=3.2.204>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech62><b>OF SYRACUSE</b></a>
+<A NAME=speech62><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=3.2.205>What I should think of this, I cannot tell:</A><br>
 <A NAME=3.2.206>But this I think, there's no man is so vain</A><br>
@@ -2235,10 +2135,9 @@
 <A NAME=speech3><b>Officer</b></a>
 <blockquote>
 <A NAME=4.1.14>That labour may you save: see where he comes.</A><br>
-<A NAME=4.1.15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech4><b>OF EPHESUS</b></a>
+<A NAME=speech4><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.16>While I go to the goldsmith's house, go thou</A><br>
 <A NAME=4.1.17>And buy a rope's end: that will I bestow</A><br>
@@ -2252,10 +2151,9 @@
 <blockquote>
 <A NAME=4.1.22>I buy a thousand pound a year: I buy a rope.</A><br>
 <p><i>Exit</i></p>
-<A NAME=4.1.23>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF EPHESUS</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.24>A man is well holp up that trusts to you:</A><br>
 <A NAME=4.1.25>I promised your presence and the chain;</A><br>
@@ -2273,10 +2171,9 @@
 <A NAME=4.1.33>Than I stand debted to this gentleman:</A><br>
 <A NAME=4.1.34>I pray you, see him presently discharged,</A><br>
 <A NAME=4.1.35>For he is bound to sea and stays but for it.</A><br>
-<A NAME=4.1.36>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF EPHESUS</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.37>I am not furnish'd with the present money;</A><br>
 <A NAME=4.1.38>Besides, I have some business in the town.</A><br>
@@ -2289,10 +2186,9 @@
 <A NAME=speech9><b>ANGELO</b></a>
 <blockquote>
 <A NAME=4.1.43>Then you will bring the chain to her yourself?</A><br>
-<A NAME=4.1.44>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF EPHESUS</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.45>No; bear it with you, lest I come not time enough.</A><br>
 </blockquote>
@@ -2300,10 +2196,9 @@
 <A NAME=speech11><b>ANGELO</b></a>
 <blockquote>
 <A NAME=4.1.46>Well, sir, I will. Have you the chain about you?</A><br>
-<A NAME=4.1.47>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech12><b>OF EPHESUS</b></a>
+<A NAME=speech12><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.48>An if I have not, sir, I hope you have;</A><br>
 <A NAME=4.1.49>Or else you may return without your money.</A><br>
@@ -2314,10 +2209,9 @@
 <A NAME=4.1.50>Nay, come, I pray you, sir, give me the chain:</A><br>
 <A NAME=4.1.51>Both wind and tide stays for this gentleman,</A><br>
 <A NAME=4.1.52>And I, to blame, have held him here too long.</A><br>
-<A NAME=4.1.53>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF EPHESUS</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.54>Good Lord! you use this dalliance to excuse</A><br>
 <A NAME=4.1.55>Your breach of promise to the Porpentine.</A><br>
@@ -2333,10 +2227,9 @@
 <A NAME=speech16><b>ANGELO</b></a>
 <blockquote>
 <A NAME=4.1.59>You hear how he importunes me;--the chain!</A><br>
-<A NAME=4.1.60>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech17><b>OF EPHESUS</b></a>
+<A NAME=speech17><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.61>Why, give it to my wife and fetch your money.</A><br>
 </blockquote>
@@ -2345,10 +2238,9 @@
 <blockquote>
 <A NAME=4.1.62>Come, come, you know I gave it you even now.</A><br>
 <A NAME=4.1.63>Either send the chain or send me by some token.</A><br>
-<A NAME=4.1.64>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech19><b>OF EPHESUS</b></a>
+<A NAME=speech19><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.65>Fie, now you run this humour out of breath,</A><br>
 <A NAME=4.1.66>where's the chain? I pray you, let me see it.</A><br>
@@ -2359,10 +2251,9 @@
 <A NAME=4.1.67>My business cannot brook this dalliance.</A><br>
 <A NAME=4.1.68>Good sir, say whether you'll answer me or no:</A><br>
 <A NAME=4.1.69>If not, I'll leave him to the officer.</A><br>
-<A NAME=4.1.70>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech21><b>OF EPHESUS</b></a>
+<A NAME=speech21><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.71>I answer you! what should I answer you?</A><br>
 </blockquote>
@@ -2370,10 +2261,9 @@
 <A NAME=speech22><b>ANGELO</b></a>
 <blockquote>
 <A NAME=4.1.72>The money that you owe me for the chain.</A><br>
-<A NAME=4.1.73>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech23><b>OF EPHESUS</b></a>
+<A NAME=speech23><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.74>I owe you none till I receive the chain.</A><br>
 </blockquote>
@@ -2381,10 +2271,9 @@
 <A NAME=speech24><b>ANGELO</b></a>
 <blockquote>
 <A NAME=4.1.75>You know I gave it you half an hour since.</A><br>
-<A NAME=4.1.76>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech25><b>OF EPHESUS</b></a>
+<A NAME=speech25><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.77>You gave me none: you wrong me much to say so.</A><br>
 </blockquote>
@@ -2410,10 +2299,9 @@
 <A NAME=4.1.82>This touches me in reputation.</A><br>
 <A NAME=4.1.83>Either consent to pay this sum for me</A><br>
 <A NAME=4.1.84>Or I attach you by this officer.</A><br>
-<A NAME=4.1.85>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech30><b>OF EPHESUS</b></a>
+<A NAME=speech30><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.86>Consent to pay thee that I never had!</A><br>
 <A NAME=4.1.87>Arrest me, foolish fellow, if thou darest.</A><br>
@@ -2429,10 +2317,9 @@
 <A NAME=speech32><b>Officer</b></a>
 <blockquote>
 <A NAME=4.1.91>I do arrest you, sir: you hear the suit.</A><br>
-<A NAME=4.1.92>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech33><b>OF EPHESUS</b></a>
+<A NAME=speech33><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.93>I do obey thee till I give thee bail.</A><br>
 <A NAME=4.1.94>But, sirrah, you shall buy this sport as dear</A><br>
@@ -2456,10 +2343,9 @@
 <A NAME=4.1.103>The ship is in her trim; the merry wind</A><br>
 <A NAME=4.1.104>Blows fair from land: they stay for nought at all</A><br>
 <A NAME=4.1.105>But for their owner, master, and yourself.</A><br>
-<A NAME=4.1.106>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech36><b>OF EPHESUS</b></a>
+<A NAME=speech36><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.107>How now! a madman! Why, thou peevish sheep,</A><br>
 <A NAME=4.1.108>What ship of Epidamnum stays for me?</A><br>
@@ -2468,10 +2354,9 @@
 <A NAME=speech37><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.1.109>A ship you sent me to, to hire waftage.</A><br>
-<A NAME=4.1.110>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech38><b>OF EPHESUS</b></a>
+<A NAME=speech38><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.111>Thou drunken slave, I sent thee for a rope;</A><br>
 <A NAME=4.1.112>And told thee to what purpose and what end.</A><br>
@@ -2481,10 +2366,9 @@
 <blockquote>
 <A NAME=4.1.113>You sent me for a rope's end as soon:</A><br>
 <A NAME=4.1.114>You sent me to the bay, sir, for a bark.</A><br>
-<A NAME=4.1.115>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech40><b>OF EPHESUS</b></a>
+<A NAME=speech40><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.1.116>I will debate this matter at more leisure</A><br>
 <A NAME=4.1.117>And teach your ears to list me with more heed.</A><br>
@@ -2725,11 +2609,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Syracuse</i>
 </blockquote>
-<blockquote>
-<A NAME=4.3.1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF SYRACUSE</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.2>There's not a man I meet but doth salute me</A><br>
 <A NAME=4.3.3>As if I were their well-acquainted friend;</A><br>
@@ -2749,10 +2630,9 @@
 <blockquote>
 <A NAME=4.3.13>Master, here's the gold you sent me for. What, have</A><br>
 <A NAME=4.3.14>you got the picture of old Adam new-apparelled?</A><br>
-<A NAME=4.3.15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF SYRACUSE</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.16>What gold is this? what Adam dost thou mean?</A><br>
 </blockquote>
@@ -2764,10 +2644,9 @@
 <A NAME=4.3.19>skin that was killed for the Prodigal; he that came</A><br>
 <A NAME=4.3.20>behind you, sir, like an evil angel, and bid you</A><br>
 <A NAME=4.3.21>forsake your liberty.</A><br>
-<A NAME=4.3.22>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF SYRACUSE</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.23>I understand thee not.</A><br>
 </blockquote>
@@ -2781,10 +2660,9 @@
 <A NAME=4.3.28>men and gives them suits of durance; he that sets up</A><br>
 <A NAME=4.3.29>his rest to do more exploits with his mace than a</A><br>
 <A NAME=4.3.30>morris-pike.</A><br>
-<A NAME=4.3.31>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF SYRACUSE</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.32>What, thou meanest an officer?</A><br>
 </blockquote>
@@ -2795,10 +2673,9 @@
 <A NAME=4.3.34>any man to answer it that breaks his band; one that</A><br>
 <A NAME=4.3.35>thinks a man always going to bed, and says, 'God</A><br>
 <A NAME=4.3.36>give you good rest!'</A><br>
-<A NAME=4.3.37>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF SYRACUSE</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.38>Well, sir, there rest in your foolery. Is there any</A><br>
 </blockquote>
@@ -2810,10 +2687,9 @@
 <A NAME=4.3.41>you hindered by the sergeant, to tarry for the hoy</A><br>
 <A NAME=4.3.42>Delay. Here are the angels that you sent for to</A><br>
 <A NAME=4.3.43>deliver you.</A><br>
-<A NAME=4.3.44>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech11><b>OF SYRACUSE</b></a>
+<A NAME=speech11><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.45>The fellow is distract, and so am I;</A><br>
 <A NAME=4.3.46>And here we wander in illusions:</A><br>
@@ -2826,10 +2702,9 @@
 <A NAME=4.3.48>Well met, well met, Master Antipholus.</A><br>
 <A NAME=4.3.49>I see, sir, you have found the goldsmith now:</A><br>
 <A NAME=4.3.50>Is that the chain you promised me to-day?</A><br>
-<A NAME=4.3.51>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech13><b>OF SYRACUSE</b></a>
+<A NAME=speech13><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.52>Satan, avoid! I charge thee, tempt me not.</A><br>
 </blockquote>
@@ -2837,10 +2712,9 @@
 <A NAME=speech14><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.53>Master, is this Mistress Satan?</A><br>
-<A NAME=4.3.54>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech15><b>OF SYRACUSE</b></a>
+<A NAME=speech15><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.55>It is the devil.</A><br>
 </blockquote>
@@ -2866,10 +2740,9 @@
 <blockquote>
 <A NAME=4.3.65>Master, if you do, expect spoon-meat; or bespeak a</A><br>
 <A NAME=4.3.66>long spoon.</A><br>
-<A NAME=4.3.67>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech19><b>OF SYRACUSE</b></a>
+<A NAME=speech19><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.68>Why, Dromio?</A><br>
 </blockquote>
@@ -2878,10 +2751,9 @@
 <blockquote>
 <A NAME=4.3.69>Marry, he must have a long spoon that must eat with</A><br>
 <A NAME=4.3.70>the devil.</A><br>
-<A NAME=4.3.71>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech21><b>OF SYRACUSE</b></a>
+<A NAME=speech21><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.72>Avoid then, fiend! what tell'st thou me of supping?</A><br>
 <A NAME=4.3.73>Thou art, as you are all, a sorceress:</A><br>
@@ -2909,10 +2781,9 @@
 <blockquote>
 <A NAME=4.3.84>I pray you, sir, my ring, or else the chain:</A><br>
 <A NAME=4.3.85>I hope you do not mean to cheat me so.</A><br>
-<A NAME=4.3.86>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech25><b>OF SYRACUSE</b></a>
+<A NAME=speech25><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.3.87>Avaunt, thou witch! Come, Dromio, let us go.</A><br>
 </blockquote>
@@ -2947,11 +2818,8 @@
 <p><blockquote>
 <i>Enter ANTIPHOLUS of Ephesus and the Officer</i>
 </blockquote>
-<blockquote>
-<A NAME=4.4.1>ANTIPHOLUS</A><br>
-</blockquote>
 
-<A NAME=speech1><b>OF EPHESUS</b></a>
+<A NAME=speech1><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.2>Fear me not, man; I will not break away:</A><br>
 <A NAME=4.4.3>I'll give thee, ere I leave thee, so much money,</A><br>
@@ -2968,10 +2836,9 @@
 <A NAME=speech2><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.11>Here's that, I warrant you, will pay them all.</A><br>
-<A NAME=4.4.12>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech3><b>OF EPHESUS</b></a>
+<A NAME=speech3><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.13>But where's the money?</A><br>
 </blockquote>
@@ -2979,10 +2846,9 @@
 <A NAME=speech4><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.14>Why, sir, I gave the money for the rope.</A><br>
-<A NAME=4.4.15>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech5><b>OF EPHESUS</b></a>
+<A NAME=speech5><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.16>Five hundred ducats, villain, for a rope?</A><br>
 </blockquote>
@@ -2990,10 +2856,9 @@
 <A NAME=speech6><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.17>I'll serve you, sir, five hundred at the rate.</A><br>
-<A NAME=4.4.18>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech7><b>OF EPHESUS</b></a>
+<A NAME=speech7><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.19>To what end did I bid thee hie thee home?</A><br>
 </blockquote>
@@ -3001,10 +2866,9 @@
 <A NAME=speech8><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.20>To a rope's-end, sir; and to that end am I returned.</A><br>
-<A NAME=4.4.21>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech9><b>OF EPHESUS</b></a>
+<A NAME=speech9><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.22>And to that end, sir, I will welcome you.</A><br>
 <p><i>Beating him</i></p>
@@ -3028,10 +2892,9 @@
 <A NAME=speech13><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.26>Nay, rather persuade him to hold his hands.</A><br>
-<A NAME=4.4.27>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech14><b>OF EPHESUS</b></a>
+<A NAME=speech14><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.28>Thou whoreson, senseless villain!</A><br>
 </blockquote>
@@ -3061,10 +2924,9 @@
 <A NAME=4.4.41>I return; nay, I bear it on my shoulders, as a</A><br>
 <A NAME=4.4.42>beggar wont her brat; and, I think when he hath</A><br>
 <A NAME=4.4.43>lamed me, I shall beg with it from door to door.</A><br>
-<A NAME=4.4.44>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech18><b>OF EPHESUS</b></a>
+<A NAME=speech18><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.45>Come, go along; my wife is coming yonder.</A><br>
 <p><i>Enter ADRIANA, LUCIANA, the Courtezan, and PINCH</i></p>
@@ -3075,10 +2937,9 @@
 <A NAME=4.4.46>Mistress, 'respice finem,' respect your end; or</A><br>
 <A NAME=4.4.47>rather, the prophecy like the parrot, 'beware the</A><br>
 <A NAME=4.4.48>rope's-end.'</A><br>
-<A NAME=4.4.49>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech20><b>OF EPHESUS</b></a>
+<A NAME=speech20><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.50>Wilt thou still talk?</A><br>
 <p><i>Beating him</i></p>
@@ -3110,10 +2971,9 @@
 <A NAME=speech25><b>PINCH</b></a>
 <blockquote>
 <A NAME=4.4.58>Give me your hand and let me feel your pulse.</A><br>
-<A NAME=4.4.59>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech26><b>OF EPHESUS</b></a>
+<A NAME=speech26><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.60>There is my hand, and let it feel your ear.</A><br>
 <p><i>Striking him</i></p>
@@ -3125,10 +2985,9 @@
 <A NAME=4.4.62>To yield possession to my holy prayers</A><br>
 <A NAME=4.4.63>And to thy state of darkness hie thee straight:</A><br>
 <A NAME=4.4.64>I conjure thee by all the saints in heaven!</A><br>
-<A NAME=4.4.65>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech28><b>OF EPHESUS</b></a>
+<A NAME=speech28><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.66>Peace, doting wizard, peace! I am not mad.</A><br>
 </blockquote>
@@ -3136,10 +2995,9 @@
 <A NAME=speech29><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=4.4.67>O, that thou wert not, poor distressed soul!</A><br>
-<A NAME=4.4.68>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech30><b>OF EPHESUS</b></a>
+<A NAME=speech30><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.69>You minion, you, are these your customers?</A><br>
 <A NAME=4.4.70>Did this companion with the saffron face</A><br>
@@ -3153,10 +3011,9 @@
 <A NAME=4.4.74>O husband, God doth know you dined at home;</A><br>
 <A NAME=4.4.75>Where would you had remain'd until this time,</A><br>
 <A NAME=4.4.76>Free from these slanders and this open shame!</A><br>
-<A NAME=4.4.77>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech32><b>OF EPHESUS</b></a>
+<A NAME=speech32><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.78>Dined at home! Thou villain, what sayest thou?</A><br>
 </blockquote>
@@ -3164,10 +3021,9 @@
 <A NAME=speech33><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.79>Sir, sooth to say, you did not dine at home.</A><br>
-<A NAME=4.4.80>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech34><b>OF EPHESUS</b></a>
+<A NAME=speech34><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.81>Were not my doors lock'd up and I shut out?</A><br>
 </blockquote>
@@ -3175,10 +3031,9 @@
 <A NAME=speech35><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.82>Perdie, your doors were lock'd and you shut out.</A><br>
-<A NAME=4.4.83>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech36><b>OF EPHESUS</b></a>
+<A NAME=speech36><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.84>And did not she herself revile me there?</A><br>
 </blockquote>
@@ -3186,10 +3041,9 @@
 <A NAME=speech37><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.85>Sans fable, she herself reviled you there.</A><br>
-<A NAME=4.4.86>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech38><b>OF EPHESUS</b></a>
+<A NAME=speech38><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.87>Did not her kitchen-maid rail, taunt, and scorn me?</A><br>
 </blockquote>
@@ -3197,10 +3051,9 @@
 <A NAME=speech39><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.88>Certes, she did; the kitchen-vestal scorn'd you.</A><br>
-<A NAME=4.4.89>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech40><b>OF EPHESUS</b></a>
+<A NAME=speech40><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.90>And did not I in rage depart from thence?</A><br>
 </blockquote>
@@ -3220,10 +3073,9 @@
 <blockquote>
 <A NAME=4.4.94>It is no shame: the fellow finds his vein,</A><br>
 <A NAME=4.4.95>And yielding to him humours well his frenzy.</A><br>
-<A NAME=4.4.96>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech44><b>OF EPHESUS</b></a>
+<A NAME=speech44><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.97>Thou hast suborn'd the goldsmith to arrest me.</A><br>
 </blockquote>
@@ -3238,10 +3090,9 @@
 <blockquote>
 <A NAME=4.4.100>Money by me! heart and goodwill you might;</A><br>
 <A NAME=4.4.101>But surely master, not a rag of money.</A><br>
-<A NAME=4.4.102>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech47><b>OF EPHESUS</b></a>
+<A NAME=speech47><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.103>Went'st not thou to her for a purse of ducats?</A><br>
 </blockquote>
@@ -3267,10 +3118,9 @@
 <A NAME=4.4.108>Mistress, both man and master is possess'd;</A><br>
 <A NAME=4.4.109>I know it by their pale and deadly looks:</A><br>
 <A NAME=4.4.110>They must be bound and laid in some dark room.</A><br>
-<A NAME=4.4.111>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech52><b>OF EPHESUS</b></a>
+<A NAME=speech52><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.112>Say, wherefore didst thou lock me forth to-day?</A><br>
 <A NAME=4.4.113>And why dost thou deny the bag of gold?</A><br>
@@ -3290,10 +3140,9 @@
 <A NAME=speech55><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=4.4.117>Dissembling villain, thou speak'st false in both.</A><br>
-<A NAME=4.4.118>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech56><b>OF EPHESUS</b></a>
+<A NAME=speech56><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.119>Dissembling harlot, thou art false in all;</A><br>
 <A NAME=4.4.120>And art confederate with a damned pack</A><br>
@@ -3316,10 +3165,9 @@
 <A NAME=speech59><b>LUCIANA</b></a>
 <blockquote>
 <A NAME=4.4.126>Ay me, poor man, how pale and wan he looks!</A><br>
-<A NAME=4.4.127>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech60><b>OF EPHESUS</b></a>
+<A NAME=speech60><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.128>What, will you murder me? Thou gaoler, thou,</A><br>
 <A NAME=4.4.129>I am thy prisoner: wilt thou suffer them</A><br>
@@ -3358,10 +3206,9 @@
 <A NAME=4.4.141>And, knowing how the debt grows, I will pay it.</A><br>
 <A NAME=4.4.142>Good master doctor, see him safe convey'd</A><br>
 <A NAME=4.4.143>Home to my house. O most unhappy day!</A><br>
-<A NAME=4.4.144>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech66><b>OF EPHESUS</b></a>
+<A NAME=speech66><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.145>O most unhappy strumpet!</A><br>
 </blockquote>
@@ -3369,10 +3216,9 @@
 <A NAME=speech67><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.146>Master, I am here entered in bond for you.</A><br>
-<A NAME=4.4.147>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech68><b>OF EPHESUS</b></a>
+<A NAME=speech68><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=4.4.148>Out on thee, villain! wherefore dost thou mad me?</A><br>
 </blockquote>
@@ -3456,10 +3302,9 @@
 <blockquote>
 <A NAME=4.4.170>Away! they'll kill us.</A><br>
 <p><i>Exeunt all but Antipholus of Syracuse and Dromio of Syracuse</i></p>
-<A NAME=4.4.171>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech83><b>OF SYRACUSE</b></a>
+<A NAME=speech83><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.4.172>I see these witches are afraid of swords.</A><br>
 </blockquote>
@@ -3467,10 +3312,9 @@
 <A NAME=speech84><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.4.173>She that would be your wife now ran from you.</A><br>
-<A NAME=4.4.174>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech85><b>OF SYRACUSE</b></a>
+<A NAME=speech85><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.4.175>Come to the Centaur; fetch our stuff from thence:</A><br>
 <A NAME=4.4.176>I long that we were safe and sound aboard.</A><br>
@@ -3484,10 +3328,9 @@
 <A NAME=4.4.180>the mountain of mad flesh that claims marriage of</A><br>
 <A NAME=4.4.181>me, I could find in my heart to stay here still and</A><br>
 <A NAME=4.4.182>turn witch.</A><br>
-<A NAME=4.4.183>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech87><b>OF SYRACUSE</b></a>
+<A NAME=speech87><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=4.4.184>I will not stay to-night for all the town;</A><br>
 <A NAME=4.4.185>Therefore away, to get our stuff aboard.</A><br>
@@ -3540,10 +3383,9 @@
 <A NAME=5.1.20>Who, but for staying on our controversy,</A><br>
 <A NAME=5.1.21>Had hoisted sail and put to sea to-day:</A><br>
 <A NAME=5.1.22>This chain you had of me; can you deny it?</A><br>
-<A NAME=5.1.23>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech6><b>OF SYRACUSE</b></a>
+<A NAME=speech6><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.24>I think I had; I never did deny it.</A><br>
 </blockquote>
@@ -3551,10 +3393,9 @@
 <A NAME=speech7><b>Second Merchant</b></a>
 <blockquote>
 <A NAME=5.1.25>Yes, that you did, sir, and forswore it too.</A><br>
-<A NAME=5.1.26>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech8><b>OF SYRACUSE</b></a>
+<A NAME=speech8><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.27>Who heard me to deny it or forswear it?</A><br>
 </blockquote>
@@ -3564,10 +3405,9 @@
 <A NAME=5.1.28>These ears of mine, thou know'st did hear thee.</A><br>
 <A NAME=5.1.29>Fie on thee, wretch! 'tis pity that thou livest</A><br>
 <A NAME=5.1.30>To walk where any honest man resort.</A><br>
-<A NAME=5.1.31>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech10><b>OF SYRACUSE</b></a>
+<A NAME=speech10><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.32>Thou art a villain to impeach me thus:</A><br>
 <A NAME=5.1.33>I'll prove mine honour and mine honesty</A><br>
@@ -3925,10 +3765,9 @@
 <A NAME=5.1.193>Even now we housed him in the abbey here;</A><br>
 <A NAME=5.1.194>And now he's there, past thought of human reason.</A><br>
 <p><i>Enter ANTIPHOLUS of Ephesus and DROMIO of Ephesus</i></p>
-<A NAME=5.1.195>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech57><b>OF EPHESUS</b></a>
+<A NAME=speech57><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.196>Justice, most gracious duke, O, grant me justice!</A><br>
 <A NAME=5.1.197>Even for the service that long since I did thee,</A><br>
@@ -3941,10 +3780,9 @@
 <blockquote>
 <A NAME=5.1.201>Unless the fear of death doth make me dote,</A><br>
 <A NAME=5.1.202>I see my son Antipholus and Dromio.</A><br>
-<A NAME=5.1.203>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech59><b>OF EPHESUS</b></a>
+<A NAME=speech59><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.204>Justice, sweet prince, against that woman there!</A><br>
 <A NAME=5.1.205>She whom thou gavest to me to be my wife,</A><br>
@@ -3957,10 +3795,9 @@
 <A NAME=speech60><b>DUKE SOLINUS</b></a>
 <blockquote>
 <A NAME=5.1.210>Discover how, and thou shalt find me just.</A><br>
-<A NAME=5.1.211>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech61><b>OF EPHESUS</b></a>
+<A NAME=speech61><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.212>This day, great duke, she shut the doors upon me,</A><br>
 <A NAME=5.1.213>While she with harlots feasted in my house.</A><br>
@@ -3988,10 +3825,9 @@
 <blockquote>
 <A NAME=5.1.220>O perjured woman! They are both forsworn:</A><br>
 <A NAME=5.1.221>In this the madman justly chargeth them.</A><br>
-<A NAME=5.1.222>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech66><b>OF EPHESUS</b></a>
+<A NAME=speech66><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.223>My liege, I am advised what I say,</A><br>
 <A NAME=5.1.224>Neither disturbed with the effect of wine,</A><br>
@@ -4061,10 +3897,9 @@
 <A NAME=5.1.272>And thereupon I drew my sword on you;</A><br>
 <A NAME=5.1.273>And then you fled into this abbey here,</A><br>
 <A NAME=5.1.274>From whence, I think, you are come by miracle.</A><br>
-<A NAME=5.1.275>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech71><b>OF EPHESUS</b></a>
+<A NAME=speech71><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.276>I never came within these abbey-walls,</A><br>
 <A NAME=5.1.277>Nor ever didst thou draw thy sword on me:</A><br>
@@ -4090,10 +3925,9 @@
 <A NAME=speech74><b>Courtezan</b></a>
 <blockquote>
 <A NAME=5.1.287>He did, and from my finger snatch'd that ring.</A><br>
-<A NAME=5.1.288>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech75><b>OF EPHESUS</b></a>
+<A NAME=speech75><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.289>'Tis true, my liege; this ring I had of her.</A><br>
 </blockquote>
@@ -4168,10 +4002,9 @@
 <A NAME=5.1.310>And careful hours with time's deformed hand</A><br>
 <A NAME=5.1.311>Have written strange defeatures in my face:</A><br>
 <A NAME=5.1.312>But tell me yet, dost thou not know my voice?</A><br>
-<A NAME=5.1.313>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech88><b>OF EPHESUS</b></a>
+<A NAME=speech88><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.314>Neither.</A><br>
 </blockquote>
@@ -4211,10 +4044,9 @@
 <A NAME=5.1.329>My dull deaf ears a little use to hear:</A><br>
 <A NAME=5.1.330>All these old witnesses--I cannot err--</A><br>
 <A NAME=5.1.331>Tell me thou art my son Antipholus.</A><br>
-<A NAME=5.1.332>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech94><b>OF EPHESUS</b></a>
+<A NAME=speech94><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.333>I never saw my father in my life.</A><br>
 </blockquote>
@@ -4224,10 +4056,9 @@
 <A NAME=5.1.334>But seven years since, in Syracusa, boy,</A><br>
 <A NAME=5.1.335>Thou know'st we parted: but perhaps, my son,</A><br>
 <A NAME=5.1.336>Thou shamest to acknowledge me in misery.</A><br>
-<A NAME=5.1.337>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech96><b>OF EPHESUS</b></a>
+<A NAME=speech96><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.338>The duke and all that know me in the city</A><br>
 <A NAME=5.1.339>Can witness with me that it is not so</A><br>
@@ -4269,10 +4100,9 @@
 <A NAME=speech102><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.351>I, sir, am Dromio; pray, let me stay.</A><br>
-<A NAME=5.1.352>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech103><b>OF SYRACUSE</b></a>
+<A NAME=speech103><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.353>AEgeon art thou not? or else his ghost?</A><br>
 </blockquote>
@@ -4320,10 +4150,9 @@
 <A NAME=5.1.376>These are the parents to these children,</A><br>
 <A NAME=5.1.377>Which accidentally are met together.</A><br>
 <A NAME=5.1.378>Antipholus, thou camest from Corinth first?</A><br>
-<A NAME=5.1.379>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech109><b>OF SYRACUSE</b></a>
+<A NAME=speech109><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.380>No, sir, not I; I came from Syracuse.</A><br>
 </blockquote>
@@ -4331,10 +4160,9 @@
 <A NAME=speech110><b>DUKE SOLINUS</b></a>
 <blockquote>
 <A NAME=5.1.381>Stay, stand apart; I know not which is which.</A><br>
-<A NAME=5.1.382>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech111><b>OF EPHESUS</b></a>
+<A NAME=speech111><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.383>I came from Corinth, my most gracious lord,--</A><br>
 </blockquote>
@@ -4342,10 +4170,9 @@
 <A NAME=speech112><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.384>And I with him.</A><br>
-<A NAME=5.1.385>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech113><b>OF EPHESUS</b></a>
+<A NAME=speech113><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.386>Brought to this town by that most famous warrior,</A><br>
 <A NAME=5.1.387>Duke Menaphon, your most renowned uncle.</A><br>
@@ -4354,10 +4181,9 @@
 <A NAME=speech114><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=5.1.388>Which of you two did dine with me to-day?</A><br>
-<A NAME=5.1.389>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech115><b>OF SYRACUSE</b></a>
+<A NAME=speech115><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.390>I, gentle mistress.</A><br>
 </blockquote>
@@ -4365,16 +4191,14 @@
 <A NAME=speech116><b>ADRIANA</b></a>
 <blockquote>
 <A NAME=5.1.391>And are not you my husband?</A><br>
-<A NAME=5.1.392>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech117><b>OF EPHESUS</b></a>
+<A NAME=speech117><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.393>No; I say nay to that.</A><br>
-<A NAME=5.1.394>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech118><b>OF SYRACUSE</b></a>
+<A NAME=speech118><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.395>And so do I; yet did she call me so:</A><br>
 <A NAME=5.1.396>And this fair gentlewoman, her sister here,</A><br>
@@ -4388,16 +4212,14 @@
 <A NAME=speech119><b>ANGELO</b></a>
 <blockquote>
 <A NAME=5.1.401>That is the chain, sir, which you had of me.</A><br>
-<A NAME=5.1.402>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech120><b>OF SYRACUSE</b></a>
+<A NAME=speech120><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.403>I think it be, sir; I deny it not.</A><br>
-<A NAME=5.1.404>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech121><b>OF EPHESUS</b></a>
+<A NAME=speech121><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.405>And you, sir, for this chain arrested me.</A><br>
 </blockquote>
@@ -4416,20 +4238,18 @@
 <A NAME=speech124><b>DROMIO OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.409>No, none by me.</A><br>
-<A NAME=5.1.410>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech125><b>OF SYRACUSE</b></a>
+<A NAME=speech125><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.411>This purse of ducats I received from you,</A><br>
 <A NAME=5.1.412>And Dromio, my man, did bring them me.</A><br>
 <A NAME=5.1.413>I see we still did meet each other's man,</A><br>
 <A NAME=5.1.414>And I was ta'en for him, and he for me,</A><br>
 <A NAME=5.1.415>And thereupon these errors are arose.</A><br>
-<A NAME=5.1.416>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech126><b>OF EPHESUS</b></a>
+<A NAME=speech126><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.417>These ducats pawn I for my father here.</A><br>
 </blockquote>
@@ -4442,10 +4262,9 @@
 <A NAME=speech128><b>Courtezan</b></a>
 <blockquote>
 <A NAME=5.1.419>Sir, I must have that diamond from you.</A><br>
-<A NAME=5.1.420>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech129><b>OF EPHESUS</b></a>
+<A NAME=speech129><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.421>There, take it; and much thanks for my good cheer.</A><br>
 </blockquote>
@@ -4477,10 +4296,9 @@
 <A NAME=speech132><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.437>Master, shall I fetch your stuff from shipboard?</A><br>
-<A NAME=5.1.438>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech133><b>OF EPHESUS</b></a>
+<A NAME=speech133><b>ANTIPHOLUS OF EPHESUS</b></a>
 <blockquote>
 <A NAME=5.1.439>Dromio, what stuff of mine hast thou embark'd?</A><br>
 </blockquote>
@@ -4488,10 +4306,9 @@
 <A NAME=speech134><b>DROMIO OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.440>Your goods that lay at host, sir, in the Centaur.</A><br>
-<A NAME=5.1.441>ANTIPHOLUS</A><br>
 </blockquote>
 
-<A NAME=speech135><b>OF SYRACUSE</b></a>
+<A NAME=speech135><b>ANTIPHOLUS OF SYRACUSE</b></a>
 <blockquote>
 <A NAME=5.1.442>He speaks to me. I am your master, Dromio:</A><br>
 <A NAME=5.1.443>Come, go with us; we'll look to that anon:</A><br>

--- a/coriolanus/coriolanus.3.1.html
+++ b/coriolanus/coriolanus.3.1.html
@@ -526,7 +526,10 @@
 <A NAME=speech70><b>CORIOLANUS</b></a>
 <blockquote>
 <A NAME=218>Hence, old goat!</A><br>
-<A NAME=219>Senators,  & C	We'll surety him.</A><br>
+</blockquote>
+
+<A NAME=speech70><b>Senators</b></a>
+<A NAME=219>We'll surety him.</A><br>
 </blockquote>
 
 <A NAME=speech71><b>COMINIUS</b></a>
@@ -564,7 +567,11 @@
 <A NAME=speech77><b>Citizens</b></a>
 <blockquote>
 <A NAME=227>Down with him! down with him!</A><br>
-<A NAME=228>Senators,  & C	Weapons, weapons, weapons!</A><br>
+</blockquote>
+
+<A NAME=speech77><b>Second Senator</b></a>
+<blockquote>
+<A NAME=228>Weapons, weapons, weapons!</A><br>
 <p><i>They all bustle about CORIOLANUS, crying</i></p>
 <A NAME=229>'Tribunes!' 'Patricians!' 'Citizens!' 'What, ho!'</A><br>
 <A NAME=230>'Sicinius!' 'Brutus!' 'Coriolanus!' 'Citizens!'</A><br>

--- a/coriolanus/full.html
+++ b/coriolanus/full.html
@@ -4097,7 +4097,10 @@
 <A NAME=speech70><b>CORIOLANUS</b></a>
 <blockquote>
 <A NAME=3.1.218>Hence, old goat!</A><br>
-<A NAME=3.1.219>Senators,  & C	We'll surety him.</A><br>
+</blockquote>
+
+<A NAME=speech70><b>Senators</b></a>
+<A NAME=3.1.219>We'll surety him.</A><br>
 </blockquote>
 
 <A NAME=speech71><b>COMINIUS</b></a>
@@ -4135,7 +4138,11 @@
 <A NAME=speech77><b>Citizens</b></a>
 <blockquote>
 <A NAME=3.1.227>Down with him! down with him!</A><br>
-<A NAME=3.1.228>Senators,  & C	Weapons, weapons, weapons!</A><br>
+</blockquote>
+
+<A NAME=speech77><b>Second Senator</b></a>
+<blockquote>
+<A NAME=3.1.228> Weapons, weapons, weapons!</A><br>
 <p><i>They all bustle about CORIOLANUS, crying</i></p>
 <A NAME=3.1.229>'Tribunes!' 'Patricians!' 'Citizens!' 'What, ho!'</A><br>
 <A NAME=3.1.230>'Sicinius!' 'Brutus!' 'Coriolanus!' 'Citizens!'</A><br>

--- a/cymbeline/cymbeline.2.2.html
+++ b/cymbeline/cymbeline.2.2.html
@@ -110,7 +110,7 @@
 <p><i>Goes into the trunk. The scene closes</i></p>
 </blockquote>
 
-<A NAME=speech7><b>Scene III</b></a>
+<A NAME=speech7><b>SCENE III</b></a>
 <blockquote>
 <A NAME=55>An ante-chamber adjoining Imogen's apartments.</A><br>
 <p><i>Enter CLOTEN and Lords</i></p>

--- a/cymbeline/cymbeline.5.4.html
+++ b/cymbeline/cymbeline.5.4.html
@@ -235,7 +235,7 @@
 <p><i>The Apparitions vanish</i></p>
 </blockquote>
 
-<A NAME=speech21><b>Posthumus Leonatus</b></a>
+<A NAME=speech21><b>POSTHUMUS LEONATUS</b></a>
 <blockquote>
 <A NAME=125>[Waking]  Sleep, thou hast been a grandsire, and begot</A><br>
 <A NAME=126>A father to me; and thou hast created</A><br>

--- a/cymbeline/full.html
+++ b/cymbeline/full.html
@@ -6170,7 +6170,7 @@
 <p><i>The Apparitions vanish</i></p>
 </blockquote>
 
-<A NAME=speech21><b>Posthumus Leonatus</b></a>
+<A NAME=speech21><b>POSTHUMUS LEONATUS</b></a>
 <blockquote>
 <A NAME=5.4.125>[Waking]  Sleep, thou hast been a grandsire, and begot</A><br>
 <A NAME=5.4.126>A father to me; and thou hast created</A><br>

--- a/cymbeline/full.html
+++ b/cymbeline/full.html
@@ -2008,7 +2008,7 @@
 <p><i>Goes into the trunk. The scene closes</i></p>
 </blockquote>
 
-<A NAME=speech7><b>Scene III</b></a>
+<A NAME=speech7><b>SCENE III</b></a>
 <blockquote>
 <A NAME=2.2.55>An ante-chamber adjoining Imogen's apartments.</A><br>
 <p><i>Enter CLOTEN and Lords</i></p>

--- a/hamlet/full.html
+++ b/hamlet/full.html
@@ -5671,9 +5671,7 @@
 <A NAME=4.2.1>Safely stowed.</A><br>
 </blockquote>
 
-<A NAME=speech2><b>ROSENCRANTZ:</b></a>
-
-<A NAME=speech3><b>GUILDENSTERN:</b></a>
+<A NAME=speech2><b>ROSENCRANTZ and GUILDENSTERN</b></a>
 <blockquote>
 <A NAME=4.2.2>[Within]  Hamlet! Lord Hamlet!</A><br>
 </blockquote>

--- a/hamlet/hamlet.4.2.html
+++ b/hamlet/hamlet.4.2.html
@@ -32,9 +32,7 @@
 <A NAME=1>Safely stowed.</A><br>
 </blockquote>
 
-<A NAME=speech2><b>ROSENCRANTZ:</b></a>
-
-<A NAME=speech3><b>GUILDENSTERN:</b></a>
+<A NAME=speech2><b>ROSENCRANTZ and GUILDENSTERN</b></a>
 <blockquote>
 <A NAME=2>[Within]  Hamlet! Lord Hamlet!</A><br>
 </blockquote>

--- a/henryv/full.html
+++ b/henryv/full.html
@@ -6409,7 +6409,8 @@
 <A NAME=5.2.370>Then shall I swear to Kate, and you to me;</A><br>
 <A NAME=5.2.371>And may our oaths well kept and prosperous be!</A><br>
 <p><i>Sennet. Exeunt</i></p>
-<A NAME=5.2.372>EPILOGUE</A><br>
+
+<h3>EPILOGUE</h3>
 <p><i>Enter Chorus</i></p>
 </blockquote>
 

--- a/julius_caesar/full.html
+++ b/julius_caesar/full.html
@@ -149,11 +149,7 @@
 <A NAME=1.1.60>See whether their basest metal be not moved;</A><br>
 <A NAME=1.1.61>They vanish tongue-tied in their guiltiness.</A><br>
 <A NAME=1.1.62>Go you down that way towards the Capitol;</A><br>
-</blockquote>
-
-<A NAME=speech17><b>This way will I</b></a>
-<blockquote>
-<A NAME=1.1.63>disrobe the images,</A><br>
+<A NAME=1.1.63>This way will I. Disrobe the images,</A><br>
 <A NAME=1.1.64>If you do find them deck'd with ceremonies.</A><br>
 </blockquote>
 

--- a/julius_caesar/julius_caesar.1.1.html
+++ b/julius_caesar/julius_caesar.1.1.html
@@ -151,11 +151,7 @@
 <A NAME=60>See whether their basest metal be not moved;</A><br>
 <A NAME=61>They vanish tongue-tied in their guiltiness.</A><br>
 <A NAME=62>Go you down that way towards the Capitol;</A><br>
-</blockquote>
-
-<A NAME=speech17><b>This way will I</b></a>
-<blockquote>
-<A NAME=63>disrobe the images,</A><br>
+<A NAME=63>This way will I. Disrobe the images,</A><br>
 <A NAME=64>If you do find them deck'd with ceremonies.</A><br>
 </blockquote>
 

--- a/lear/full.html
+++ b/lear/full.html
@@ -165,7 +165,7 @@
 <A NAME=1.1.63>Love, and be silent.</A><br>
 </blockquote>
 
-<A NAME=speech20><b>LEAR</b></a>
+<A NAME=speech20><b>KING LEAR</b></a>
 <blockquote>
 <A NAME=1.1.64>Of all these bounds, even from this line to this,</A><br>
 <A NAME=1.1.65>With shadowy forests and with champains rich'd,</A><br>

--- a/lear/lear.1.1.html
+++ b/lear/lear.1.1.html
@@ -167,7 +167,7 @@
 <A NAME=63>Love, and be silent.</A><br>
 </blockquote>
 
-<A NAME=speech20><b>LEAR</b></a>
+<A NAME=speech20><b>KING LEAR</b></a>
 <blockquote>
 <A NAME=64>Of all these bounds, even from this line to this,</A><br>
 <A NAME=65>With shadowy forests and with champains rich'd,</A><br>

--- a/lll/full.html
+++ b/lll/full.html
@@ -5787,11 +5787,7 @@
 <blockquote>
 <A NAME=5.2.416>Thus pour the stars down plagues for perjury.</A><br>
 <A NAME=5.2.417>Can any face of brass hold longer out?</A><br>
-</blockquote>
-
-<A NAME=speech193><b>Here stand I</b></a>
-<blockquote>
-<A NAME=5.2.418>lady, dart thy skill at me;</A><br>
+<A NAME=5.2.418>Here stand I lady, dart thy skill at me;</A><br>
 <A NAME=5.2.419>Bruise me with scorn, confound me with a flout;</A><br>
 <A NAME=5.2.420>Thrust thy sharp wit quite through my ignorance;</A><br>
 <A NAME=5.2.421>Cut me to pieces with thy keen conceit;</A><br>

--- a/lll/lll.5.2.html
+++ b/lll/lll.5.2.html
@@ -1225,11 +1225,7 @@
 <blockquote>
 <A NAME=416>Thus pour the stars down plagues for perjury.</A><br>
 <A NAME=417>Can any face of brass hold longer out?</A><br>
-</blockquote>
-
-<A NAME=speech193><b>Here stand I</b></a>
-<blockquote>
-<A NAME=418>lady, dart thy skill at me;</A><br>
+<A NAME=418>Here stand I lady, dart thy skill at me;</A><br>
 <A NAME=419>Bruise me with scorn, confound me with a flout;</A><br>
 <A NAME=420>Thrust thy sharp wit quite through my ignorance;</A><br>
 <A NAME=421>Cut me to pieces with thy keen conceit;</A><br>

--- a/measure/full.html
+++ b/measure/full.html
@@ -2508,11 +2508,7 @@
 <A NAME=speech7><b>ANGELO</b></a>
 <blockquote>
 <A NAME=2.4.38>Yet may he live awhile; and, it may be,</A><br>
-</blockquote>
-
-<A NAME=speech8><b>As long as you or I</b></a>
-<blockquote>
-<A NAME=2.4.39>yet he must die.</A><br>
+<A NAME=2.4.39>As long as you or I, yet he must die.</A><br>
 </blockquote>
 
 <A NAME=speech9><b>ISABELLA</b></a>

--- a/measure/full.html
+++ b/measure/full.html
@@ -1534,7 +1534,7 @@
 <A NAME=2.1.186>So. What trade are you of, sir?</A><br>
 </blockquote>
 
-<A NAME=speech78><b>POMPHEY</b></a>
+<A NAME=speech78><b>POMPEY</b></a>
 <blockquote>
 <A NAME=2.1.187>Tapster; a poor widow's tapster.</A><br>
 </blockquote>
@@ -1544,7 +1544,7 @@
 <A NAME=2.1.188>Your mistress' name?</A><br>
 </blockquote>
 
-<A NAME=speech80><b>POMPHEY</b></a>
+<A NAME=speech80><b>POMPEY</b></a>
 <blockquote>
 <A NAME=2.1.189>Mistress Overdone.</A><br>
 </blockquote>

--- a/measure/measure.2.1.html
+++ b/measure/measure.2.1.html
@@ -524,7 +524,7 @@
 <A NAME=186>So. What trade are you of, sir?</A><br>
 </blockquote>
 
-<A NAME=speech78><b>POMPHEY</b></a>
+<A NAME=speech78><b>POMPEY</b></a>
 <blockquote>
 <A NAME=187>Tapster; a poor widow's tapster.</A><br>
 </blockquote>
@@ -534,7 +534,7 @@
 <A NAME=188>Your mistress' name?</A><br>
 </blockquote>
 
-<A NAME=speech80><b>POMPHEY</b></a>
+<A NAME=speech80><b>POMPEY</b></a>
 <blockquote>
 <A NAME=189>Mistress Overdone.</A><br>
 </blockquote>

--- a/measure/measure.2.4.html
+++ b/measure/measure.2.4.html
@@ -94,11 +94,7 @@
 <A NAME=speech7><b>ANGELO</b></a>
 <blockquote>
 <A NAME=38>Yet may he live awhile; and, it may be,</A><br>
-</blockquote>
-
-<A NAME=speech8><b>As long as you or I</b></a>
-<blockquote>
-<A NAME=39>yet he must die.</A><br>
+<A NAME=39>As long as you or I, yet he must die.</A><br>
 </blockquote>
 
 <A NAME=speech9><b>ISABELLA</b></a>

--- a/merry_wives/full.html
+++ b/merry_wives/full.html
@@ -3442,11 +3442,7 @@
 <p><i>Enter PAGE, SHALLOW, SLENDER, Host, SIR HUGH EVANS, DOCTOR CAIUS, and RUGBY</i></p>
 </blockquote>
 
-<A NAME=speech16><b>SHALLOW</b></a>
-
-<A NAME=speech17><b>PAGE</b></a>
-
-<A NAME=speech18><b>& C</b></a>
+<A NAME=speech16><b>SHALLOW, PAGE, etc</b></a>
 <blockquote>
 <A NAME=3.2.44>Well met, Master Ford.</A><br>
 </blockquote>

--- a/merry_wives/merry_wives.3.2.html
+++ b/merry_wives/merry_wives.3.2.html
@@ -134,11 +134,7 @@
 <p><i>Enter PAGE, SHALLOW, SLENDER, Host, SIR HUGH EVANS, DOCTOR CAIUS, and RUGBY</i></p>
 </blockquote>
 
-<A NAME=speech16><b>SHALLOW</b></a>
-
-<A NAME=speech17><b>PAGE</b></a>
-
-<A NAME=speech18><b>& C</b></a>
+<A NAME=speech16><b>SHALLOW, PAGE, etc.</b></a>
 <blockquote>
 <A NAME=44>Well met, Master Ford.</A><br>
 </blockquote>

--- a/midsummer/full.html
+++ b/midsummer/full.html
@@ -2375,7 +2375,7 @@
 <A NAME=3.2.239>This you should pity rather than despise.</A><br>
 </blockquote>
 
-<A NAME=speech46><b>HERNIA</b></a>
+<A NAME=speech46><b>HERMIA</b></a>
 <blockquote>
 <A NAME=3.2.240>I understand not what you mean by this.</A><br>
 </blockquote>

--- a/midsummer/midsummer.3.2.html
+++ b/midsummer/midsummer.3.2.html
@@ -454,7 +454,7 @@
 <A NAME=239>This you should pity rather than despise.</A><br>
 </blockquote>
 
-<A NAME=speech46><b>HERNIA</b></a>
+<A NAME=speech46><b>HERMIA</b></a>
 <blockquote>
 <A NAME=240>I understand not what you mean by this.</A><br>
 </blockquote>

--- a/othello/full.html
+++ b/othello/full.html
@@ -1588,7 +1588,7 @@
 <p><i>Guns heard</i></p>
 </blockquote>
 
-<A NAME=speech19><b>Second Gentlemen</b></a>
+<A NAME=speech19><b>Second Gentleman</b></a>
 <blockquote>
 <A NAME=2.1.60>They do discharge their shot of courtesy:</A><br>
 <A NAME=2.1.61>Our friends at least.</A><br>

--- a/othello/othello.2.1.html
+++ b/othello/othello.2.1.html
@@ -163,7 +163,7 @@
 <p><i>Guns heard</i></p>
 </blockquote>
 
-<A NAME=speech19><b>Second Gentlemen</b></a>
+<A NAME=speech19><b>Second Gentleman</b></a>
 <blockquote>
 <A NAME=60>They do discharge their shot of courtesy:</A><br>
 <A NAME=61>Our friends at least.</A><br>

--- a/richardiii/full.html
+++ b/richardiii/full.html
@@ -2119,7 +2119,7 @@
 <A NAME=1.4.151>Where art thou, keeper? give me a cup of wine.</A><br>
 </blockquote>
 
-<A NAME=speech49><b>Second murderer</b></a>
+<A NAME=speech49><b>Second Murderer</b></a>
 <blockquote>
 <A NAME=1.4.152>You shall have wine enough, my lord, anon.</A><br>
 </blockquote>
@@ -7805,10 +7805,9 @@
 <A NAME=5.3.122>Sleeping and waking, O, defend me still!</A><br>
 <p><i>Sleeps</i></p>
 <p><i>Enter the Ghost of Prince Edward, son to King Henry VI</i></p>
-<A NAME=5.3.123>Ghost</A><br>
 </blockquote>
 
-<A NAME=speech36><b>of Prince Edward</b></a>
+<A NAME=speech36><b>Ghost of Prince Edward</b></a>
 <blockquote>
 <A NAME=5.3.124>[To KING RICHARD III]</A><br>
 <A NAME=5.3.125>Let me sit heavy on thy soul to-morrow!</A><br>
@@ -7819,10 +7818,9 @@
 <A NAME=5.3.129>Of butcher'd princes fight in thy behalf</A><br>
 <A NAME=5.3.130>King Henry's issue, Richmond, comforts thee.</A><br>
 <p><i>Enter the Ghost of King Henry VI</i></p>
-<A NAME=5.3.131>Ghost</A><br>
 </blockquote>
 
-<A NAME=speech37><b>of King Henry VI</b></a>
+<A NAME=speech37><b>Ghost of King Henry VI</b></a>
 <blockquote>
 <A NAME=5.3.132>[To KING RICHARD III]</A><br>
 <A NAME=5.3.133>When I was mortal, my anointed body</A><br>
@@ -7889,10 +7887,9 @@
 <A NAME=5.3.164>Quiet untroubled soul, awake, awake!</A><br>
 <A NAME=5.3.165>Arm, fight, and conquer, for fair England's sake!</A><br>
 <p><i>Enter the Ghosts of the two young Princes</i></p>
-<A NAME=5.3.166>Ghosts</A><br>
 </blockquote>
 
-<A NAME=speech44><b>of young Princes</b></a>
+<A NAME=speech44><b>Ghosts of young Princes</b></a>
 <blockquote>
 <A NAME=5.3.167>[To KING RICHARD III]</A><br>
 <A NAME=5.3.168>Dream on thy cousins smother'd in the Tower:</A><br>
@@ -7920,10 +7917,9 @@
 <A NAME=5.3.183>Dream of success and happy victory!</A><br>
 <A NAME=5.3.184>Thy adversary's wife doth pray for thee.</A><br>
 <p><i>Enter the Ghost of BUCKINGHAM</i></p>
-<A NAME=5.3.185>Ghost</A><br>
 </blockquote>
 
-<A NAME=speech46><b>of BUCKINGHAM</b></a>
+<A NAME=speech46><b>Ghost of BUCKINGHAM</b></a>
 <blockquote>
 <A NAME=5.3.186>[To KING RICHARD III]</A><br>
 <A NAME=5.3.187>The last was I that helped thee to the crown;</A><br>

--- a/richardiii/richardiii.1.4.html
+++ b/richardiii/richardiii.1.4.html
@@ -374,7 +374,7 @@
 <A NAME=151>Where art thou, keeper? give me a cup of wine.</A><br>
 </blockquote>
 
-<A NAME=speech49><b>Second murderer</b></a>
+<A NAME=speech49><b>Second Murderer</b></a>
 <blockquote>
 <A NAME=152>You shall have wine enough, my lord, anon.</A><br>
 </blockquote>

--- a/richardiii/richardiii.5.3.html
+++ b/richardiii/richardiii.5.3.html
@@ -298,10 +298,9 @@
 <A NAME=122>Sleeping and waking, O, defend me still!</A><br>
 <p><i>Sleeps</i></p>
 <p><i>Enter the Ghost of Prince Edward, son to King Henry VI</i></p>
-<A NAME=123>Ghost</A><br>
 </blockquote>
 
-<A NAME=speech36><b>of Prince Edward</b></a>
+<A NAME=speech36><b>Ghost of Prince Edward</b></a>
 <blockquote>
 <A NAME=124>[To KING RICHARD III]</A><br>
 <A NAME=125>Let me sit heavy on thy soul to-morrow!</A><br>
@@ -312,10 +311,9 @@
 <A NAME=129>Of butcher'd princes fight in thy behalf</A><br>
 <A NAME=130>King Henry's issue, Richmond, comforts thee.</A><br>
 <p><i>Enter the Ghost of King Henry VI</i></p>
-<A NAME=131>Ghost</A><br>
 </blockquote>
 
-<A NAME=speech37><b>of King Henry VI</b></a>
+<A NAME=speech37><b>Ghost of King Henry VI</b></a>
 <blockquote>
 <A NAME=132>[To KING RICHARD III]</A><br>
 <A NAME=133>When I was mortal, my anointed body</A><br>
@@ -382,10 +380,9 @@
 <A NAME=164>Quiet untroubled soul, awake, awake!</A><br>
 <A NAME=165>Arm, fight, and conquer, for fair England's sake!</A><br>
 <p><i>Enter the Ghosts of the two young Princes</i></p>
-<A NAME=166>Ghosts</A><br>
 </blockquote>
 
-<A NAME=speech44><b>of young Princes</b></a>
+<A NAME=speech44><b>Ghosts of young Princes</b></a>
 <blockquote>
 <A NAME=167>[To KING RICHARD III]</A><br>
 <A NAME=168>Dream on thy cousins smother'd in the Tower:</A><br>
@@ -413,10 +410,9 @@
 <A NAME=183>Dream of success and happy victory!</A><br>
 <A NAME=184>Thy adversary's wife doth pray for thee.</A><br>
 <p><i>Enter the Ghost of BUCKINGHAM</i></p>
-<A NAME=185>Ghost</A><br>
 </blockquote>
 
-<A NAME=speech46><b>of BUCKINGHAM</b></a>
+<A NAME=speech46><b>Ghost of BUCKINGHAM</b></a>
 <blockquote>
 <A NAME=186>[To KING RICHARD III]</A><br>
 <A NAME=187>The last was I that helped thee to the crown;</A><br>

--- a/romeo_juliet/full.html
+++ b/romeo_juliet/full.html
@@ -3022,7 +3022,7 @@
 <A NAME=2.4.188>I warrant thee, my man's as true as steel.</A><br>
 </blockquote>
 
-<A NAME=speech86><b>NURSE</b></a>
+<A NAME=speech86><b>Nurse</b></a>
 <blockquote>
 <A NAME=2.4.189>Well, sir; my mistress is the sweetest lady--Lord,</A><br>
 <A NAME=2.4.190>Lord! when 'twas a little prating thing:--O, there</A><br>
@@ -5250,7 +5250,7 @@
 </blockquote>
 <h3>SCENE II. Hall in Capulet's house.</h3>
 <p><blockquote>
-<i>Enter CAPULET, LADY  CAPULET, Nurse, and two Servingmen</i>
+<i>Enter CAPULET, LADY CAPULET, Nurse, and two Servingmen</i>
 </blockquote>
 
 <A NAME=speech1><b>CAPULET</b></a>
@@ -5358,7 +5358,7 @@
 <p><i>Exeunt JULIET and Nurse</i></p>
 </blockquote>
 
-<A NAME=speech17><b>LADY  CAPULET</b></a>
+<A NAME=speech17><b>LADY CAPULET</b></a>
 <blockquote>
 <A NAME=4.2.38>We shall be short in our provision:</A><br>
 <A NAME=4.2.39>'Tis now near night.</A><br>

--- a/romeo_juliet/romeo_juliet.2.4.html
+++ b/romeo_juliet/romeo_juliet.2.4.html
@@ -560,7 +560,7 @@
 <A NAME=188>I warrant thee, my man's as true as steel.</A><br>
 </blockquote>
 
-<A NAME=speech86><b>NURSE</b></a>
+<A NAME=speech86><b>Nurse</b></a>
 <blockquote>
 <A NAME=189>Well, sir; my mistress is the sweetest lady--Lord,</A><br>
 <A NAME=190>Lord! when 'twas a little prating thing:--O, there</A><br>

--- a/romeo_juliet/romeo_juliet.4.2.html
+++ b/romeo_juliet/romeo_juliet.4.2.html
@@ -24,7 +24,7 @@
 <H3>SCENE II. Hall in Capulet's house.</h3>
 
 <p><blockquote>
-<i>Enter CAPULET, LADY  CAPULET, Nurse, and two Servingmen</i>
+<i>Enter CAPULET, LADY CAPULET, Nurse, and two Servingmen</i>
 </blockquote>
 
 <A NAME=speech1><b>CAPULET</b></a>
@@ -132,7 +132,7 @@
 <p><i>Exeunt JULIET and Nurse</i></p>
 </blockquote>
 
-<A NAME=speech17><b>LADY  CAPULET</b></a>
+<A NAME=speech17><b>LADY CAPULET</b></a>
 <blockquote>
 <A NAME=38>We shall be short in our provision:</A><br>
 <A NAME=39>'Tis now near night.</A><br>

--- a/taming_shrew/full.html
+++ b/taming_shrew/full.html
@@ -3531,7 +3531,7 @@
 <A NAME=3.2.220>Ay, marry, sir, now it begins to work.</A><br>
 </blockquote>
 
-<A NAME=speech73><b>KATARINA</b></a>
+<A NAME=speech73><b>KATHARINA</b></a>
 <blockquote>
 <A NAME=3.2.221>Gentlemen, forward to the bridal dinner:</A><br>
 <A NAME=3.2.222>I see a woman may be made a fool,</A><br>
@@ -6224,7 +6224,7 @@
 <A NAME=speech67><b>BAPTISTA</b></a>
 <blockquote>
 <A NAME=5.2.111>Now, by my holidame, here comes Katharina!</A><br>
-<p><i>Re-enter KATARINA</i></p>
+<p><i>Re-enter KATHARINA</i></p>
 </blockquote>
 
 <A NAME=speech68><b>KATHARINA</b></a>

--- a/taming_shrew/full.html
+++ b/taming_shrew/full.html
@@ -18,7 +18,6 @@
     | Entire play
 </table>
 
-<H3>ACT Induction</h3>
 <h3>SCENE I. Before an alehouse on a heath.</h3>
 <p><blockquote>
 <i>Enter Hostess and SLY</i>

--- a/taming_shrew/full.html
+++ b/taming_shrew/full.html
@@ -727,7 +727,7 @@
 <A NAME=1.1.65>And paint your face and use you like a fool.</A><br>
 </blockquote>
 
-<A NAME=speech10><b>HORTENSIA</b></a>
+<A NAME=speech10><b>HORTENSIO</b></a>
 <blockquote>
 <A NAME=1.1.66>From all such devils, good Lord deliver us!</A><br>
 </blockquote>

--- a/taming_shrew/full.html
+++ b/taming_shrew/full.html
@@ -18,6 +18,7 @@
     | Entire play
 </table>
 
+<H3>ACT Induction</h3>
 <h3>SCENE I. Before an alehouse on a heath.</h3>
 <p><blockquote>
 <i>Enter Hostess and SLY</i>

--- a/taming_shrew/taming_shrew.0.0.html
+++ b/taming_shrew/taming_shrew.0.0.html
@@ -20,7 +20,7 @@
       <a href="taming_shrew.0.1.html">Next scene</A>
 </table>
 
-<h3>Induction</H3>
+<H3>ACT Induction</h3>
 
 <table width="100%" bgcolor="#CCF6F6">
 <tr><td class="nav" align="center">

--- a/taming_shrew/taming_shrew.0.1.html
+++ b/taming_shrew/taming_shrew.0.1.html
@@ -20,6 +20,7 @@
       <a href="taming_shrew.0.2.html">Next scene</A>
 </table>
 
+<h3>ACT Induction</H3>
 <h3>SCENE I. Before an alehouse on a heath.</H3>
 
 <p><blockquote>

--- a/taming_shrew/taming_shrew.0.1.html
+++ b/taming_shrew/taming_shrew.0.1.html
@@ -20,7 +20,7 @@
       <a href="taming_shrew.0.2.html">Next scene</A>
 </table>
 
-<h3>ACT Induction</H3>
+<H3>Induction</h3>
 <h3>SCENE I. Before an alehouse on a heath.</H3>
 
 <p><blockquote>

--- a/taming_shrew/taming_shrew.0.2.html
+++ b/taming_shrew/taming_shrew.0.2.html
@@ -21,6 +21,7 @@
     | <a href="taming_shrew.1.1.html">Next scene</A>
 </table>
 
+<h3>ACT Induction</H3>
 <H3>SCENE II. A bedchamber in the Lord's house.</h3>
 
 <p><blockquote>

--- a/taming_shrew/taming_shrew.0.2.html
+++ b/taming_shrew/taming_shrew.0.2.html
@@ -21,7 +21,7 @@
     | <a href="taming_shrew.1.1.html">Next scene</A>
 </table>
 
-<h3>ACT Induction</H3>
+<h3>Induction</H3>
 <H3>SCENE II. A bedchamber in the Lord's house.</h3>
 
 <p><blockquote>

--- a/taming_shrew/taming_shrew.1.1.html
+++ b/taming_shrew/taming_shrew.1.1.html
@@ -129,7 +129,7 @@
 <A NAME=65>And paint your face and use you like a fool.</A><br>
 </blockquote>
 
-<A NAME=speech10><b>HORTENSIA</b></a>
+<A NAME=speech10><b>HORTENSIO</b></a>
 <blockquote>
 <A NAME=66>From all such devils, good Lord deliver us!</A><br>
 </blockquote>

--- a/taming_shrew/taming_shrew.3.2.html
+++ b/taming_shrew/taming_shrew.3.2.html
@@ -543,7 +543,7 @@
 <A NAME=220>Ay, marry, sir, now it begins to work.</A><br>
 </blockquote>
 
-<A NAME=speech73><b>KATARINA</b></a>
+<A NAME=speech73><b>KATHARINA</b></a>
 <blockquote>
 <A NAME=221>Gentlemen, forward to the bridal dinner:</A><br>
 <A NAME=222>I see a woman may be made a fool,</A><br>

--- a/taming_shrew/taming_shrew.5.2.html
+++ b/taming_shrew/taming_shrew.5.2.html
@@ -410,7 +410,7 @@
 <A NAME=speech67><b>BAPTISTA</b></a>
 <blockquote>
 <A NAME=111>Now, by my holidame, here comes Katharina!</A><br>
-<p><i>Re-enter KATARINA</i></p>
+<p><i>Re-enter KATHARINA</i></p>
 </blockquote>
 
 <A NAME=speech68><b>KATHARINA</b></a>

--- a/zz
+++ b/zz
@@ -1,0 +1,1 @@
+vi comedy_errors/comedy_errors.4.3.html comedy_errors/comedy_errors.3.1.html comedy_errors/comedy_errors.4.2.html comedy_errors/comedy_errors.5.1.html comedy_errors/full.html comedy_errors/comedy_errors.2.2.html comedy_errors/comedy_errors.4.4.html comedy_errors/comedy_errors.4.1.html comedy_errors/comedy_errors.1.2.html comedy_errors/comedy_errors.3.2.html


### PR DESCRIPTION
There were a lot of things that I found with the names of characters and their scenes.

I've been writing some Python scripts to rip this data and create breakdowns for aspiring directors. These adjustments help the scripts become cleaner. My script is over in my github. I'll be expanding it to create a web interface for it later.